### PR TITLE
Added ability to override Config properties on every script.

### DIFF
--- a/d2bs/kolbot/libs/common/Loader.js
+++ b/d2bs/kolbot/libs/common/Loader.js
@@ -26,9 +26,52 @@ var Loader = {
 			}
 		}
 	},
+	
+	// see http://stackoverflow.com/questions/728360/copying-an-object-in-javascript#answer-728694
+	clone: function(obj) {
+		// Handle the 3 simple types, and null or undefined
+		if (null == obj || "object" != typeof obj) return obj;
+
+		// Handle Date
+		if (obj instanceof Date) {
+			var copy = new Date();
+			copy.setTime(obj.getTime());
+			return copy;
+		}
+
+		// Handle Array
+		if (obj instanceof Array) {
+			var copy = [];
+			for (var i = 0, len = obj.length; i < len; i++) {
+				copy[i] = this.clone(obj[i]);
+			}
+			return copy;
+		}
+
+		// Handle Object
+		if (obj instanceof Object) {
+			var copy = {};
+			for (var attr in obj) {
+				if (obj.hasOwnProperty(attr)) copy[attr] = this.clone(obj[attr]);
+			}
+			return copy;
+		}
+
+		throw new Error("Unable to copy obj! Its type isn't supported.");
+	},
+	
+	copy: function(from,to){
+		 for (i in from){
+			if (from.hasOwnProperty(i)){
+			   to[i] = this.clone(from[i]);                
+			}            
+		}
+	},
 
 	loadScripts: function () {
 		var i, townCheck;
+		var unmodifiedConfig = {};
+		this.copy(Config, unmodifiedConfig); 
 
 		if (!this.scriptList.length) {
 			showConsole();
@@ -40,6 +83,7 @@ ScriptLoop:
 		for (i in Scripts) {
 			if (Scripts.hasOwnProperty(i) && this.scriptList.indexOf(i) > -1 && Scripts[i]) {
 				include("bots/" + i + ".js");
+				var reconfiguration = typeof Scripts[i] === 'object';
 
 				if (typeof (global[i]) === "function") {
 					if (i !== "Test" && i !== "Follower") {
@@ -55,6 +99,10 @@ ScriptLoop:
 					if (townCheck) {
 						try {
 							print("ÿc2Starting script: ÿc9" + i);
+							if (reconfiguration){
+								print("ÿc2Copying Config properties from " + i + " object.");
+								this.copy(Scripts[i], Config);
+							}
 							global[i]();
 						} catch (e) {
 							if (this.printToOOG) {
@@ -67,6 +115,10 @@ ScriptLoop:
 								takeScreenshot();
 								delay(500);
 							}
+						}
+						if (reconfiguration){
+							print("ÿc2Reverting back unmodified config properties.");
+							this.copy(unmodifiedConfig, Config);
 						}
 					}
 				} else {


### PR DESCRIPTION
Now it is possible to alter the configuration with every script. So for instance one can reconfigure the clear type and belt configuration on Mausoleum script like so:

Scripts.Mausoleum = {ClearType : 0,BeltColumn : ["hp","hp","rv","rv"]};

So if a certain script is an object, the reconfiguration will happen. If it is just a true or false, nothing will change. 
So this just adds a new feature, it doesn't change the behavior if a user doesn't put objects as values of Script properties.

One might ask why would anyone need this. I can give one example that i had.
I wanted to change "TeleStomp", "Dodge", and "BossPriority" when my lighnint sorc was doing Diablo runs. But i wanted to change them only on those runs. Why? Because even with infinity Vizier is sometimes immune to lightning. So using this way my merc would be able to kill it without affecting how I deal with monsters that are not in the Chaos (in other places i just want to skip lightning immune monsters).
