### PR TITLE
minor mulelogger fix

### DIFF
--- a/d2bs/kolbot/libs/MuleLogger.js
+++ b/d2bs/kolbot/libs/MuleLogger.js
@@ -90,7 +90,7 @@ var MuleLogger = {
 		var i, code, desc, sock,
 			header = "",
 			color = -1,
-			name = unit.fname.split("\n").reverse().join(" ").replace(/ÿc[0-9!"+<;.*]/, "").trim();
+			name = unit.fname.split("\n").reverse().join(" ").replace(/(y|ÿ)c[0-9!"+<;.*]/, "").trim();
 
 		desc = this.getItemDesc(unit) + "$" + unit.gid;
 		color = unit.getColor();


### PR DESCRIPTION
correctly removes unnecessary characters left behind when logging
runewords/cube under non-english locale systems
