### PR TITLE
Pather.useWaypoint: ensure a waypoint menu is opened if "check" is "true"

### DIFF
--- a/d2bs/kolbot/libs/common/Pather.js
+++ b/d2bs/kolbot/libs/common/Pather.js
@@ -799,23 +799,6 @@ ModeLoop:
 					}
 
 					Misc.click(0, 0, wp);
-					delay(me.ping * 2);
-					tick = getTickCount();
-
-					while (!getUIFlag(0x14) && getTickCount() - tick < Math.max(Math.round((i + 1) * 1000 / (i / 5 + 1)), me.ping * 2)) {
-						print("useWaypoint: Waiting for waypoint menu");
-
-						if (getDistance(me, wp) > 5) {
-							this.moveToUnit(wp);
-						}
-
-						Misc.click(0, 0, wp);
-						delay(me.ping * 2);
-					}
-
-					if (!getUIFlag(0x14)) {
-						continue;
-					}
 
 					tick = getTickCount();
 
@@ -858,6 +841,10 @@ ModeLoop:
 						}
 
 						delay(10);
+					}
+
+					if (!getUIFlag(0x14)) {
+						continue;
 					}
 				}
 


### PR DESCRIPTION
When two or more characters are trying to get a waypoint simultaneously and "check" is "true", some may fail to get menu opened, hence, interact directly. D2GS derivatives treat such a behavior as a cheat and block the action (see below*). For an instance, Rubattle.net is the case (a lifetime ban guaranteed).

_D2GS output: 
2014/11/1 23:40:32.140 [cheat] minx-nec(_minx-nec)@Hcs9: packet data dump: 49120000006b000000
