### PR TITLE
Pather.js - useWaypoint: ensure a waypoint menu is opened if "check" is ...

### DIFF
--- a/d2bs/kolbot/libs/common/Pather.js
+++ b/d2bs/kolbot/libs/common/Pather.js
@@ -842,6 +842,10 @@ ModeLoop:
 
 						delay(10);
 					}
+
+					if (!getUIFlag(0x14)) {
+						continue;
+					}
 				}
 
 				delay(200);


### PR DESCRIPTION
...set to "true"

When two or more characters are trying to get a waypoint simultaneously and "check" is set to "true", some may fail to get menu opened, hence, interact directly. D2GS derivatives treat such a behavior as a cheat and block the action (see below*). For an instance, Rubattle.net is the case (a lifetime ban guaranteed).

_D2GS output: 
 2014/11/1 23:40:32.140 [cheat] minx-nec(_minx-nec)@Hcs9: packet data dump: 49120000006b000000
