### PR TITLE
Fixed broken check for charged skill

### DIFF
--- a/d2bs/kolbot/libs/common/Misc.js
+++ b/d2bs/kolbot/libs/common/Misc.js
@@ -361,16 +361,15 @@ MainLoop:
 			hand = 0;
 		}
 
-		var charge = this.getCharge(skillId);
-
+		/*var charge = this.getCharge(skillId);
 		if (!!charge) {
 			// charge.charges is a cached value from Attack.getCharges
-			/*if (charge.charges > 0 && me.setSkill(skillId, hand, charge.unit)) {
+			if (charge.charges > 0 && me.setSkill(skillId, hand, charge.unit)) {
 				return true;
-			}*/
+			}
 
 			return false;
-		}
+		}*/
 
 		if (me.setSkill(skillId, hand)) {
 			return true;
@@ -1156,14 +1155,14 @@ var Misc = {
 
 				i -= 1;
 			} else {
-				if (desc[i].match(/^(y|ÿ)c/)) {
+				if (desc[i].match(/^(y|Ã¿)c/)) {
 					stringColor = desc[i].substring(0, 3);
 				} else {
 					desc[i] = stringColor + desc[i];
 				}
 			}
 
-			desc[i] = desc[i].replace(/(y|ÿ)c([0-9!"+<;.*])/g, "\\xffc$2");
+			desc[i] = desc[i].replace(/(y|Ã¿)c([0-9!"+<;.*])/g, "\\xffc$2");
 		}
 
 		if (desc[desc.length - 1]) {
@@ -1262,7 +1261,7 @@ var Misc = {
 				return false;
 			}
 
-			desc = this.getItemDesc(unit).split("\n").join(" | ").replace(/(\\xff|ÿ)c[0-9!"+<;.*]/gi, "").trim();
+			desc = this.getItemDesc(unit).split("\n").join(" | ").replace(/(\\xff|Ã¿)c[0-9!"+<;.*]/gi, "").trim();
 
 			break;
 		case "Kept":
@@ -1272,7 +1271,7 @@ var Misc = {
 		case "Shopped":
 		case "Gambled":
 		case "Dropped":
-			desc = this.getItemDesc(unit).split("\n").join(" | ").replace(/(\\xff|ÿ)c[0-9!"+<;.*]/gi, "").trim();
+			desc = this.getItemDesc(unit).split("\n").join(" | ").replace(/(\\xff|Ã¿)c[0-9!"+<;.*]/gi, "").trim();
 
 			break;
 		case "No room for":
@@ -1280,7 +1279,7 @@ var Misc = {
 
 			break;
 		default:
-			desc = unit.fname.split("\n").reverse().join(" ").replace(/(\\xff|ÿ)c[0-9!"+<;.*]/gi, "").trim();
+			desc = unit.fname.split("\n").reverse().join(" ").replace(/(\\xff|Ã¿)c[0-9!"+<;.*]/gi, "").trim();
 
 			break;
 		}
@@ -1296,7 +1295,7 @@ var Misc = {
 
 		var i, lastArea, code, desc, sock, itemObj,
 			color = -1,
-			name = unit.fname.split("\n").reverse().join(" ").replace(/ÿc[0-9!"+<;.*]/, "").trim();
+			name = unit.fname.split("\n").reverse().join(" ").replace(/Ã¿c[0-9!"+<;.*]/, "").trim();
 
 		desc = this.getItemDesc(unit);
 		color = unit.getColor();
@@ -1751,13 +1750,13 @@ MainLoop:
 
 		if (typeof error === "string") {
 			msg = error;
-			oogmsg = error.replace(/ÿc[0-9!"+<;.*]/gi, "");
-			filemsg = "[" + (h < 10 ? "0" + h : h) + ":" + (m < 10 ? "0" + m : m) + ":" + (s < 10 ? "0" + s : s) + "] <" + me.profile + "> " + error.replace(/ÿc[0-9!"+<;.*]/gi, "") + "\n";
+			oogmsg = error.replace(/Ã¿c[0-9!"+<;.*]/gi, "");
+			filemsg = "[" + (h < 10 ? "0" + h : h) + ":" + (m < 10 ? "0" + m : m) + ":" + (s < 10 ? "0" + s : s) + "] <" + me.profile + "> " + error.replace(/Ã¿c[0-9!"+<;.*]/gi, "") + "\n";
 		} else {
 			source = error.fileName.substring(error.fileName.lastIndexOf("\\") + 1, error.fileName.length);
-			msg = "ÿc1Error in ÿc0" + script + " ÿc1(" + source + " line ÿc1" + error.lineNumber + "): ÿc1" + error.message;
+			msg = "Ã¿c1Error in Ã¿c0" + script + " Ã¿c1(" + source + " line Ã¿c1" + error.lineNumber + "): Ã¿c1" + error.message;
 			oogmsg = " Error in " + script + " (" + source + " #" + error.lineNumber + ") " + error.message + " (Area: " + me.area + ", Ping:" + me.ping + ", Game: " + me.gamename + ")";
-			filemsg = "[" + (h < 10 ? "0" + h : h) + ":" + (m < 10 ? "0" + m : m) + ":" + (s < 10 ? "0" + s : s) + "] <" + me.profile + "> " + msg.replace(/ÿc[0-9!"+<;.*]/gi, "") + "\n";
+			filemsg = "[" + (h < 10 ? "0" + h : h) + ":" + (m < 10 ? "0" + m : m) + ":" + (s < 10 ? "0" + s : s) + "] <" + me.profile + "> " + msg.replace(/Ã¿c[0-9!"+<;.*]/gi, "") + "\n";
 
 			if (error.hasOwnProperty("stack")) {
 				stack = error.stack;


### PR DESCRIPTION
The charged skill check was broken because it actually never used the charged version, it just returned false if it found one. I'm not sure why the charge cast was commented out so I just fixed the issue by removing the charge check altogether.

Also, the logic here also seems flawed as I would assume you would want to use the non-charged version first and only use the charged version if you didn't have a non-charged? Consider equipping an item with teleport charges as a sorc, would you use all your charges before using your normal teleport skill? This would ramp up the repair bill pretty significantly.

(I don't know why the change set is so big, I just made this pull request through github so I'm guessing it's inconsistent line endings)
