### PR TITLE
Energy Shield precast with +es lvl items

### DIFF
--- a/d2bs/kolbot/libs/common/Attacks/Sorceress.js
+++ b/d2bs/kolbot/libs/common/Attacks/Sorceress.js
@@ -12,7 +12,7 @@ var ClassAttack = {
 		}
 
 		if (!me.getState(30) && me.getSkill(58, 1)) {
-			Skill.cast(58, 0);
+            Precast.energyshield(); //Energy Shield
 		}
 
 		if (preattack && Config.AttackSkill[0] > 0 && Attack.checkResist(unit, Config.AttackSkill[0]) && (!me.getState(121) || !Skill.isTimed(Config.AttackSkill[0]))) {

--- a/d2bs/kolbot/libs/common/Precast.js
+++ b/d2bs/kolbot/libs/common/Precast.js
@@ -97,6 +97,7 @@ var Precast = new function () {
 			}
 
 			break;
+		case 58: // Energy Shield
 		case 52: // Enchant
 			sumCurr = 0;
 			sumSwap = 0;

--- a/d2bs/kolbot/libs/common/Precast.js
+++ b/d2bs/kolbot/libs/common/Precast.js
@@ -159,7 +159,7 @@ var Precast = new function () {
 			}
 
 			if (!me.getState(30) || force) {
-				Skill.cast(58, 0); // Energy Shield
+				this.energyshield(); //Energy Shield
 			}
 
 			if ((!me.getState(88) && !me.getState(10) && !me.getState(20)) || force) {
@@ -474,4 +474,23 @@ MainLoop:
 
 		return true;
 	};
+	
+    this.energyshield = function () {
+        var swapped,
+            slot = this.getBetterSlot(58);
+
+        if (slot !== me.weaponswitch) {
+            swapped = true;
+        }
+
+        this.weaponSwitch(slot);
+
+        Skill.cast(58, 0);
+
+        if (swapped) {
+            this.weaponSwitch(Math.abs(slot - 1));
+        }
+
+        return true;
+    };	
 };

--- a/d2bs/kolbot/libs/common/Town.js
+++ b/d2bs/kolbot/libs/common/Town.js
@@ -713,12 +713,11 @@ MainLoop:
 				}
 
 				switch (result.result) {
-                case 0:
-                    Misc.itemLogger("Dropped", unids[i], "cainID");
-                    this.initNPC("Shop", "clearInventory");
-                    unids[i].sell();
+				case 0:
+					Misc.itemLogger("Dropped", unids[i], "cainID");
+					unids[i].drop();
 
-                    break;
+					break;
 				case 1:
 					Misc.itemLogger("Kept", unids[i]);
 					Misc.logItem("Kept", unids[i], result.line);

--- a/d2bs/kolbot/libs/common/Town.js
+++ b/d2bs/kolbot/libs/common/Town.js
@@ -713,11 +713,12 @@ MainLoop:
 				}
 
 				switch (result.result) {
-				case 0:
-					Misc.itemLogger("Dropped", unids[i], "cainID");
-					unids[i].drop();
+                case 0:
+                    Misc.itemLogger("Dropped", unids[i], "cainID");
+                    this.initNPC("Shop", "clearInventory");
+                    unids[i].sell();
 
-					break;
+                    break;
 				case 1:
 					Misc.itemLogger("Kept", unids[i]);
 					Misc.logItem("Kept", unids[i], result.line);


### PR DESCRIPTION
**this was canceled** ... **fixed Cain ID then sell items**
Town.js fix for id at Cain and sell items
By default, identifying items at Cain will drop items if the requirements to keep aren't fulfilled.
In character configuration file, the value of this variable can be set to a lower limit, already in the toon's pocket.
Config.CainID.MinGold = xxx; // Minimum gold (stash + character) to have in order to use Cain.