### PR TITLE
Replace 0xFF characters with escaped hex (\xFF)

### DIFF
--- a/d2bs/kolbot/D2BotChannel.dbj
+++ b/d2bs/kolbot/D2BotChannel.dbj
@@ -463,7 +463,7 @@ MainLoop:
 		D2Bot.updateStatus("Join Game");
 
 		if (joinInfo.gameName !== "") {
-			print("ÿc2Joining ÿc0" + joinInfo.gameName);
+			print("\xFFc2Joining \xFFc0" + joinInfo.gameName);
 			ControlAction.setText(1, 606, 148, 155, 20, joinInfo.gamePass);
 			ControlAction.setText(1, 432, 148, 155, 20, joinInfo.gameName);
 

--- a/d2bs/kolbot/D2BotFollow.dbj
+++ b/d2bs/kolbot/D2BotFollow.dbj
@@ -237,7 +237,7 @@ function main() {
 		while (me.ingame) { // returns true before actually in game so we can't only use this check
 			if (me.gameReady) { // returns false when switching acts so we can't use while
 				if (!ingame) {
-					print("ÿc4Updating Status");
+					print("\xFFc4Updating Status");
 					//D2Bot.updateStatus("Game: " + me.gamename);
 
 					lastGameStatus = "ingame";

--- a/d2bs/kolbot/D2BotLead.dbj
+++ b/d2bs/kolbot/D2BotLead.dbj
@@ -492,7 +492,7 @@ MainSwitch:
 					if (ControlAction.joinChannel(chanInfo.joinChannel[i])) {
 						useChat = true;
 					} else {
-						print("ÿc1Unable to join channel, disabling chat messages.");
+						print("\xFFc1Unable to join channel, disabling chat messages.");
 
 						useChat = false;
 					}

--- a/d2bs/kolbot/D2BotMuleLog.dbj
+++ b/d2bs/kolbot/D2BotMuleLog.dbj
@@ -288,7 +288,7 @@ MainSwitch:
 		charList = chars[0];
 		obj.currAcc = currAcc[0];
 
-		print("ÿc4Mule Loggerÿc2: Login account: " + currAcc[0]);
+		print("\xFFc4Mule Logger\xFFc2: Login account: " + currAcc[0]);
 		FileTools.writeText("logs/MuleLog.json", JSON.stringify(obj));
 		ControlAction.loginAccount({account: currAcc[0], password: currAcc[1], realm: currAcc[2]});
 
@@ -443,7 +443,7 @@ MainSwitch:
 		currChar = charList.shift();
 		obj.currChar = currChar;
 
-		print("ÿc4Mule Loggerÿc2: Login character: " + currChar);
+		print("\xFFc4Mule Logger\xFFc2: Login character: " + currChar);
 		FileTools.writeText("logs/MuleLog.json", JSON.stringify(obj));
 		ControlAction.loginCharacter({charName: currChar});
 

--- a/d2bs/kolbot/D2BotPubJoin.dbj
+++ b/d2bs/kolbot/D2BotPubJoin.dbj
@@ -469,7 +469,7 @@ MainSwitch:
 
 			for (i = 0; i < gameList.length; i += 1) {
 				if (doneGames.indexOf(gameList[i].gameName) === -1 && includeCheck(gameList[i].gameName) && excludeCheck(gameList[i].gameName)) {
-					print("ÿc7Game: " + gameList[i].gameName + ", Players: " + gameList[i].players);
+					print("\xFFc7Game: " + gameList[i].gameName + ", Players: " + gameList[i].players);
 
 					gameToJoin = gameList[i].gameName;
 

--- a/d2bs/kolbot/default.dbj
+++ b/d2bs/kolbot/default.dbj
@@ -151,7 +151,7 @@ function main() {
 	}
 
 	if (Config.FastPick) {
-		print("ÿc2Fast pickit active.");
+		print("\xFFc2Fast pickit active.");
 		addEventListener("itemaction", this.itemEvent);
 	}
 

--- a/d2bs/kolbot/libs/AutoMule.js
+++ b/d2bs/kolbot/libs/AutoMule.js
@@ -327,15 +327,15 @@ MainLoop:
 		sendCopyData(null, muleObj.muleProfile, 11, "begin");
 
 		if (this.torchAnniCheck === 2) {
-			print("ÿc4AutoMuleÿc0: In anni mule game.");
+			print("\xFFc4AutoMule\xFFc0: In anni mule game.");
 			D2Bot.updateStatus("AutoMule: In game.");
 			this.dropCharm(true);
 		} else if (this.torchAnniCheck === 1) {
-			print("ÿc4AutoMuleÿc0: In torch mule game.");
+			print("\xFFc4AutoMule\xFFc0: In torch mule game.");
 			D2Bot.updateStatus("AutoMule: In game.");
 			this.dropCharm(false);
 		} else {
-			print("ÿc4AutoMuleÿc0: In mule game.");
+			print("\xFFc4AutoMule\xFFc0: In mule game.");
 			D2Bot.updateStatus("AutoMule: In game.");
 			this.dropStuff();
 		}

--- a/d2bs/kolbot/libs/MuleLogger.js
+++ b/d2bs/kolbot/libs/MuleLogger.js
@@ -47,14 +47,14 @@ var MuleLogger = {
 
 				i -= 1;
 			} else {
-				if (desc[i].match(/^(y|ÿ)c/)) {
+				if (desc[i].match(/^(y|\xFF)c/)) {
 					stringColor = desc[i].substring(0, 3);
 				} else {
 					desc[i] = stringColor + desc[i];
 				}
 			}
 
-			desc[i] = desc[i].replace(/(y|ÿ)c([0-9!"+<;.*])/g, "\\xffc$2").replace("\xFF", "\\xff", "g");
+			desc[i] = desc[i].replace(/(y|\xFF)c([0-9!"+<;.*])/g, "\\xffc$2").replace("\xFF", "\\xff", "g");
 		}
 
 		if (logIlvl && desc[desc.length - 1]) {
@@ -68,7 +68,7 @@ var MuleLogger = {
 
 	inGameCheck: function () {
 		if (getScript("D2BotMuleLog.dbj") && this.LogGame[0] && me.gamename.match(this.LogGame[0], "i")) {
-			print("ÿc4MuleLoggerÿc0: Logging items on " + me.name + ".");
+			print("\xFFc4MuleLogger\xFFc0: Logging items on " + me.name + ".");
 			D2Bot.printToConsole("MuleLogger: Logging items on " + me.name + ".", 7);
 			this.logChar();
 
@@ -98,7 +98,7 @@ var MuleLogger = {
 		var i, code, desc, sock,
 			header = "",
 			color = -1,
-			name = unit.itemType + "_" + unit.fname.split("\n").reverse().join(" ").replace(/(y|ÿ)c[0-9!"+<;.*]|\/|\\/, "").trim();
+			name = unit.itemType + "_" + unit.fname.split("\n").reverse().join(" ").replace(/(y|\xFF)c[0-9!"+<;.*]|\/|\\/, "").trim();
 
 		desc = this.getItemDesc(unit, logIlvl) + "$" + unit.gid;
 		color = unit.getColor();

--- a/d2bs/kolbot/libs/OOG.js
+++ b/d2bs/kolbot/libs/OOG.js
@@ -273,7 +273,7 @@ var D2Bot = {
 			args: []
 		};
 
-		//print("ÿc1Heart beat " + this.handle);
+		//print("\xFFc1Heart beat " + this.handle);
 		sendCopyData(null, this.handle, 0, JSON.stringify(obj));
 	},
 

--- a/d2bs/kolbot/libs/TorchSystem.js
+++ b/d2bs/kolbot/libs/TorchSystem.js
@@ -94,7 +94,7 @@ var TorchSystem = {
 
 		for (i = 0; i < farmers.length; i += 1) {
 			if (farmers[i].FarmGame.length > 0 && me.gamename.toLowerCase().match(farmers[i].FarmGame.toLowerCase())) {
-				print("ÿc4Torch Systemÿc0: In Farm game.");
+				print("\xFFc4Torch System\xFFc0: In Farm game.");
 				D2Bot.printToConsole("Torch System: In Farm game.", 7);
 				Town.goToTown(1);
 
@@ -149,7 +149,7 @@ var TorchSystem = {
 
 		for (i = 0; i < farmers.length; i += 1) {
 			if (farmers[i].FarmGame.length > 0 && me.gamename.toLowerCase().match(farmers[i].FarmGame.toLowerCase())) {
-				print("ÿc4Torch Systemÿc0: In Farm game.");
+				print("\xFFc4Torch System\xFFc0: In Farm game.");
 				D2Bot.printToConsole("Torch System: Transfering keys.", 7);
 				D2Bot.updateStatus("Torch System: In game.");
 				Town.goToTown(1);

--- a/d2bs/kolbot/libs/bots/ShopBot.js
+++ b/d2bs/kolbot/libs/bots/ShopBot.js
@@ -18,14 +18,14 @@ function ShopBot() {
 			filename = filepath.substring(filepath.lastIndexOf("/") + 1, filepath.length);
 
 		if (!FileTools.exists(filepath)) {
-			Misc.errorReport("ÿc1NIP file doesn't exist: ÿc0" + filepath);
+			Misc.errorReport("\xFFc1NIP file doesn't exist: \xFFc0" + filepath);
 			return false;
 		}
 
 		try {
 			nipfile = File.open(filepath, 0);
 		} catch (fileError) {
-			Misc.errorReport("ÿc1Failed to load NIP: ÿc0" + filename);
+			Misc.errorReport("\xFFc1Failed to load NIP: \xFFc0" + filename);
 		}
 
 		if (!nipfile) {
@@ -250,7 +250,7 @@ function ShopBot() {
 			if (NTIPAliasClassID.hasOwnProperty(Config.ShopBot.ScanIDs[i].replace(/\s+/g, "").toLowerCase())) {
 				Config.ShopBot.ScanIDs[i] = NTIPAliasClassID[Config.ShopBot.ScanIDs[i].replace(/\s+/g, "").toLowerCase()];
 			} else {
-				Misc.errorReport("ÿc1Invalid ShopBot entry:ÿc0 " + Config.ShopBot.ScanIDs[i]);
+				Misc.errorReport("\xFFc1Invalid ShopBot entry:\xFFc0 " + Config.ShopBot.ScanIDs[i]);
 				Config.ShopBot.ScanIDs.splice(i, 1);
 				i -= 1;
 			}

--- a/d2bs/kolbot/libs/common/Attack.js
+++ b/d2bs/kolbot/libs/common/Attack.js
@@ -18,7 +18,7 @@ var Attack = {
 
 		if (Config.AttackSkill[1] < 0 || Config.AttackSkill[3] < 0) {
 			showConsole();
-			print("ÿc1Bad attack config. Don't expect your bot to attack.");
+			print("\xFFc1Bad attack config. Don't expect your bot to attack.");
 		}
 
 		if (me.gametype === 1) {
@@ -425,7 +425,7 @@ var Attack = {
 
 					// Skip non-unique monsters after 15 attacks, except in Throne of Destruction
 					if (me.area !== 131 && !(target.spectype & 0x7) && gidAttack[i].attacks > 15) {
-						print("ÿc1Skipping " + target.name + " " + target.gid + " " + gidAttack[i].attacks);
+						print("\xFFc1Skipping " + target.name + " " + target.gid + " " + gidAttack[i].attacks);
 						monsterList.shift();
 					}
 
@@ -579,7 +579,7 @@ var Attack = {
 
 					// Skip non-unique monsters after 15 attacks, except in Throne of Destruction
 					if (me.area !== 131 && !(target.spectype & 0x7) && gidAttack[i].attacks > 15) {
-						print("ÿc1Skipping " + target.name + " " + target.gid + " " + gidAttack[i].attacks);
+						print("\xFFc1Skipping " + target.name + " " + target.gid + " " + gidAttack[i].attacks);
 						monsterList.shift();
 					}
 
@@ -1434,7 +1434,7 @@ AuraLoop: // Skip monsters with auras
 				}
 			}
 
-			//print("ÿc9potential spots: ÿc2" + coords.length);
+			//print("\xFFc9potential spots: \xFFc2" + coords.length);
 
 			if (coords.length > 0) {
 				coords.sort(Sort.units);
@@ -1442,7 +1442,7 @@ AuraLoop: // Skip monsters with auras
 				for (i = 0; i < coords.length; i += 1) {
 					// Valid position found
 					if (!CollMap.checkColl({x: coords[i].x, y: coords[i].y}, unit, coll, 1)) {
-						//print("ÿc9optimal pos build time: ÿc2" + (getTickCount() - t) + " ÿc9distance from target: ÿc2" + getDistance(cx, cy, unit.x, unit.y));
+						//print("\xFFc9optimal pos build time: \xFFc2" + (getTickCount() - t) + " \xFFc9distance from target: \xFFc2" + getDistance(cx, cy, unit.x, unit.y));
 
 						switch (walk) {
 						case 1:
@@ -1470,7 +1470,7 @@ AuraLoop: // Skip monsters with auras
 		}
 
 		if (name) {
-			print("ÿc4Attackÿc0: No valid positions for: " + name);
+			print("\xFFc4Attack\xFFc0: No valid positions for: " + name);
 		}
 
 		return false;

--- a/d2bs/kolbot/libs/common/Config.js
+++ b/d2bs/kolbot/libs/common/Config.js
@@ -23,7 +23,7 @@ var Config = {
 					if (CustomConfig.hasOwnProperty(n)) {
 						if (CustomConfig[n].indexOf(me.profile) > -1) {
 							if (notify) {
-								print("ÿc2Loading custom config: ÿc9" + n + ".js");
+								print("\xFFc2Loading custom config: \xFFc9" + n + ".js");
 							}
 
 							configFilename = n + ".js";
@@ -67,14 +67,14 @@ var Config = {
 			}
 		} else {
 			if (notify) {
-				print("ÿc1" + classes[me.classid] + "." + me.charname + ".js not found!"); // Use the primary format
-				print("ÿc1Loading default config.");
+				print("\xFFc1" + classes[me.classid] + "." + me.charname + ".js not found!"); // Use the primary format
+				print("\xFFc1Loading default config.");
 			}
 
 			// Try to find default config
 			if (!FileTools.exists("libs/config/" + classes[me.classid] + ".js")) {
 				D2Bot.printToConsole("Not going well? Read the wiki: https://github.com/kolton/d2bot-with-kolbot/wiki");
-				throw new Error("ÿc1Default config not found. \nÿc9     Try reading the kolbot wiki.");
+				throw new Error("\xFFc1Default config not found. \n\xFFc9     Try reading the kolbot wiki.");
 			}
 
 			try {
@@ -82,7 +82,7 @@ var Config = {
 					throw new Error();
 				}
 			} catch (e) {
-				throw new Error("ÿc1Failed to load default config.");
+				throw new Error("\xFFc1Failed to load default config.");
 			}
 		}
 
@@ -90,7 +90,7 @@ var Config = {
 			LoadConfig.call();
 		} catch (e2) {
 			if (notify) {
-				print("ÿc8Error in " + e2.fileName.substring(e2.fileName.lastIndexOf("\\") + 1, e2.fileName.length) + "(line " + e2.lineNumber + "): " + e2.message);
+				print("\xFFc8Error in " + e2.fileName.substring(e2.fileName.lastIndexOf("\\") + 1, e2.fileName.length) + "(line " + e2.lineNumber + "): " + e2.message);
 
 				throw new Error("Config.init: Error in character config.");
 			}
@@ -101,7 +101,7 @@ var Config = {
 				AutoBuild.initialize();
 			}
 		} catch (e3) {
-			print("ÿc8Error in libs/common/AutoBuild.js (AutoBuild system is not active!)");
+			print("\xFFc8Error in libs/common/AutoBuild.js (AutoBuild system is not active!)");
 			print(e3.toSource());
 		}
 	},

--- a/d2bs/kolbot/libs/common/Cubing.js
+++ b/d2bs/kolbot/libs/common/Cubing.js
@@ -113,7 +113,7 @@ var Cubing = {
 				if (NTIPAliasClassID.hasOwnProperty(Config.Recipes[i][1].replace(/\s+/g, "").toLowerCase())) {
 					Config.Recipes[i][1] = NTIPAliasClassID[Config.Recipes[i][1].replace(/\s+/g, "").toLowerCase()];
 				} else {
-					Misc.errorReport("ÿc1Invalid cubing entry:ÿc0 " + Config.Recipes[i][1]);
+					Misc.errorReport("\xFFc1Invalid cubing entry:\xFFc0 " + Config.Recipes[i][1]);
 					Config.Recipes.splice(i, 1);
 
 					i -= 1;
@@ -948,7 +948,7 @@ IngredientLoop:
 
 				transmute();
 				delay(700 + me.ping);
-				print("ÿc4Cubing: " + string);
+				print("\xFFc4Cubing: " + string);
 				D2Bot.printToConsole(string, 5);
 				this.update();
 

--- a/d2bs/kolbot/libs/common/Loader.js
+++ b/d2bs/kolbot/libs/common/Loader.js
@@ -112,19 +112,19 @@ var Loader = {
 									}
 
 									if (townCheck) {
-										print("ÿc2Starting script: ÿc9" + i);
+										print("\xFFc2Starting script: \xFFc9" + i);
 										//scriptBroadcast(JSON.stringify({currScript: i}));
 										Messaging.sendToScript("tools/toolsthread.js", JSON.stringify({currScript: i}));
 
 										if (reconfiguration) {
-											print("ÿc2Copying Config properties from " + i + " object.");
+											print("\xFFc2Copying Config properties from " + i + " object.");
 											this.copy(Scripts[i], Config);
 										}
 
 										global[i]();
 
 										if (reconfiguration) {
-											print("ÿc2Reverting back unmodified config properties.");
+											print("\xFFc2Reverting back unmodified config properties.");
 											this.copy(unmodifiedConfig, Config);
 										}
 									}
@@ -137,7 +137,7 @@ var Loader = {
 						}
 					}
 				} else {
-					Misc.errorReport("ÿc1Script " + i + " doesn't exist.");
+					Misc.errorReport("\xFFc1Script " + i + " doesn't exist.");
 				}
 			}
 		}

--- a/d2bs/kolbot/libs/common/Misc.js
+++ b/d2bs/kolbot/libs/common/Misc.js
@@ -1162,14 +1162,14 @@ var Misc = {
 
 				i -= 1;
 			} else {
-				if (desc[i].match(/^(y|ÿ)c/)) {
+				if (desc[i].match(/^(y|\xFF)c/)) {
 					stringColor = desc[i].substring(0, 3);
 				} else {
 					desc[i] = stringColor + desc[i];
 				}
 			}
 
-			desc[i] = desc[i].replace(/(y|ÿ)c([0-9!"+<;.*])/g, "\\xffc$2");
+			desc[i] = desc[i].replace(/(y|\xFF)c([0-9!"+<;.*])/g, "\\xffc$2");
 		}
 
 		if (desc[desc.length - 1]) {
@@ -1268,7 +1268,7 @@ var Misc = {
 				return false;
 			}
 
-			desc = this.getItemDesc(unit).split("\n").join(" | ").replace(/(\\xff|ÿ)c[0-9!"+<;.*]/gi, "").trim();
+			desc = this.getItemDesc(unit).split("\n").join(" | ").replace(/(\\xff|\xFF)c[0-9!"+<;.*]/gi, "").trim();
 
 			break;
 		case "Kept":
@@ -1278,7 +1278,7 @@ var Misc = {
 		case "Shopped":
 		case "Gambled":
 		case "Dropped":
-			desc = this.getItemDesc(unit).split("\n").join(" | ").replace(/(\\xff|ÿ)c[0-9!"+<;.*]|\/|\\/gi, "").trim();
+			desc = this.getItemDesc(unit).split("\n").join(" | ").replace(/(\\xff|\xFF)c[0-9!"+<;.*]|\/|\\/gi, "").trim();
 
 			break;
 		case "No room for":
@@ -1286,7 +1286,7 @@ var Misc = {
 
 			break;
 		default:
-			desc = unit.fname.split("\n").reverse().join(" ").replace(/(\\xff|ÿ)c[0-9!"+<;.*]|\/|\\/gi, "").trim();
+			desc = unit.fname.split("\n").reverse().join(" ").replace(/(\\xff|\xFF)c[0-9!"+<;.*]|\/|\\/gi, "").trim();
 
 			break;
 		}
@@ -1302,7 +1302,7 @@ var Misc = {
 
 		var i, lastArea, code, desc, sock, itemObj,
 			color = -1,
-			name = unit.fname.split("\n").reverse().join(" ").replace(/ÿc[0-9!"+<;.*]|\/|\\/, "").trim();
+			name = unit.fname.split("\n").reverse().join(" ").replace(/\xFFc[0-9!"+<;.*]|\/|\\/, "").trim();
 
 		desc = this.getItemDesc(unit);
 		color = unit.getColor();
@@ -1757,13 +1757,13 @@ MainLoop:
 
 		if (typeof error === "string") {
 			msg = error;
-			oogmsg = error.replace(/ÿc[0-9!"+<;.*]/gi, "");
-			filemsg = "[" + (h < 10 ? "0" + h : h) + ":" + (m < 10 ? "0" + m : m) + ":" + (s < 10 ? "0" + s : s) + "] <" + me.profile + "> " + error.replace(/ÿc[0-9!"+<;.*]/gi, "") + "\n";
+			oogmsg = error.replace(/\xFFc[0-9!"+<;.*]/gi, "");
+			filemsg = "[" + (h < 10 ? "0" + h : h) + ":" + (m < 10 ? "0" + m : m) + ":" + (s < 10 ? "0" + s : s) + "] <" + me.profile + "> " + error.replace(/\xFFc[0-9!"+<;.*]/gi, "") + "\n";
 		} else {
 			source = error.fileName.substring(error.fileName.lastIndexOf("\\") + 1, error.fileName.length);
-			msg = "ÿc1Error in ÿc0" + script + " ÿc1(" + source + " line ÿc1" + error.lineNumber + "): ÿc1" + error.message;
+			msg = "\xFFc1Error in \xFFc0" + script + " \xFFc1(" + source + " line \xFFc1" + error.lineNumber + "): \xFFc1" + error.message;
 			oogmsg = " Error in " + script + " (" + source + " #" + error.lineNumber + ") " + error.message + " (Area: " + me.area + ", Ping:" + me.ping + ", Game: " + me.gamename + ")";
-			filemsg = "[" + (h < 10 ? "0" + h : h) + ":" + (m < 10 ? "0" + m : m) + ":" + (s < 10 ? "0" + s : s) + "] <" + me.profile + "> " + msg.replace(/ÿc[0-9!"+<;.*]/gi, "") + "\n";
+			filemsg = "[" + (h < 10 ? "0" + h : h) + ":" + (m < 10 ? "0" + m : m) + ":" + (s < 10 ? "0" + s : s) + "] <" + me.profile + "> " + msg.replace(/\xFFc[0-9!"+<;.*]/gi, "") + "\n";
 
 			if (error.hasOwnProperty("stack")) {
 				stack = error.stack;

--- a/d2bs/kolbot/libs/common/Pickit.js
+++ b/d2bs/kolbot/libs/common/Pickit.js
@@ -132,7 +132,7 @@ var Pickit = {
 					if (!canFit) {
 						// Check if any of the current inventory items can be stashed or need to be identified and eventually sold to make room
 						if (this.canMakeRoom()) {
-							print("ÿc7Trying to make room for " + this.itemColor(pickList[0]) + pickList[0].name);
+							print("\xFFc7Trying to make room for " + this.itemColor(pickList[0]) + pickList[0].name);
 
 							// Go to town and do town chores
 							if (Town.visitTown()) {
@@ -143,14 +143,14 @@ var Pickit = {
 							}
 
 							// Town visit failed - abort
-							print("ÿc7Not enough room for " + this.itemColor(pickList[0]) + pickList[0].name);
+							print("\xFFc7Not enough room for " + this.itemColor(pickList[0]) + pickList[0].name);
 
 							return false;
 						}
 
 						// Can't make room - trigger automule
 						Misc.itemLogger("No room for", pickList[0]);
-						print("ÿc7Not enough room for " + this.itemColor(pickList[0]) + pickList[0].name);
+						print("\xFFc7Not enough room for " + this.itemColor(pickList[0]) + pickList[0].name);
 
 						needMule = true;
 					}
@@ -278,7 +278,7 @@ MainLoop:
 
 				if (stats.classid === 523) {
 					if (!item.getStat(14) || item.getStat(14) < stats.gold) {
-						print("ÿc7Picked up " + stats.color + (item.getStat(14) ? (item.getStat(14) - stats.gold) : stats.gold) + " " + stats.name);
+						print("\xFFc7Picked up " + stats.color + (item.getStat(14) ? (item.getStat(14) - stats.gold) : stats.gold) + " " + stats.name);
 
 						return true;
 					}
@@ -287,12 +287,12 @@ MainLoop:
 				if (item.mode !== 3 && item.mode !== 5) {
 					switch (stats.classid) {
 					case 543: // Key
-						print("ÿc7Picked up " + stats.color + stats.name + " ÿc7(" + Town.checkKeys() + "/12)");
+						print("\xFFc7Picked up " + stats.color + stats.name + " \xFFc7(" + Town.checkKeys() + "/12)");
 
 						return true;
 					case 529: // Scroll of Town Portal
 					case 530: // Scroll of Identify
-						print("ÿc7Picked up " + stats.color + stats.name + " ÿc7(" + Town.checkScrolls(stats.classid === 529 ? "tbk" : "ibk") + "/20)");
+						print("\xFFc7Picked up " + stats.color + stats.name + " \xFFc7(" + Town.checkScrolls(stats.classid === 529 ? "tbk" : "ibk") + "/20)");
 
 						return true;
 					}
@@ -316,7 +316,7 @@ MainLoop:
 
 			switch (status) {
 			case 1:
-				print("ÿc7Picked up " + stats.color + stats.name + " ÿc0(ilvl " + stats.ilvl + (keptLine ? ") (" + keptLine + ")" : ")"));
+				print("\xFFc7Picked up " + stats.color + stats.name + " \xFFc0(ilvl " + stats.ilvl + (keptLine ? ") (" + keptLine + ")" : ")"));
 
 				if (this.ignoreLog.indexOf(stats.type) === -1) {
 					Misc.itemLogger("Kept", item);
@@ -334,24 +334,24 @@ MainLoop:
 
 				break;
 			case 2:
-				print("ÿc7Picked up " + stats.color + stats.name + " ÿc0(ilvl " + stats.ilvl + ")" + " (Cubing)");
+				print("\xFFc7Picked up " + stats.color + stats.name + " \xFFc0(ilvl " + stats.ilvl + ")" + " (Cubing)");
 				Misc.itemLogger("Kept", item, "Cubing " + me.findItems(item.classid).length);
 				Cubing.update();
 
 				break;
 			case 3:
-				print("ÿc7Picked up " + stats.color + stats.name + " ÿc0(ilvl " + stats.ilvl + ")" + " (Runewords)");
+				print("\xFFc7Picked up " + stats.color + stats.name + " \xFFc0(ilvl " + stats.ilvl + ")" + " (Runewords)");
 				Misc.itemLogger("Kept", item, "Runewords");
 				Runewords.update(stats.classid, gid);
 
 				break;
 			case 5: // Crafting System
-				print("ÿc7Picked up " + stats.color + stats.name + " ÿc0(ilvl " + stats.ilvl + ")" + " (Crafting System)");
+				print("\xFFc7Picked up " + stats.color + stats.name + " \xFFc0(ilvl " + stats.ilvl + ")" + " (Crafting System)");
 				CraftingSystem.update(item);
 
 				break;
 			default:
-				print("ÿc7Picked up " + stats.color + stats.name + " ÿc0(ilvl " + stats.ilvl + (keptLine ? ") (" + keptLine + ")" : ")"));
+				print("\xFFc7Picked up " + stats.color + stats.name + " \xFFc0(ilvl " + stats.ilvl + (keptLine ? ") (" + keptLine + ")" : ")"));
 
 				break;
 			}
@@ -374,32 +374,32 @@ MainLoop:
 		if (type) {
 			switch (unit.itemType) {
 			case 4: // gold
-				return "ÿc4";
+				return "\xFFc4";
 			case 74: // runes
-				return "ÿc8";
+				return "\xFFc8";
 			case 76: // healing potions
-				return "ÿc1";
+				return "\xFFc1";
 			case 77: // mana potions
-				return "ÿc3";
+				return "\xFFc3";
 			case 78: // juvs
-				return "ÿc;";
+				return "\xFFc;";
 			}
 		}
 
 		switch (unit.quality) {
 		case 4: // magic
-			return "ÿc3";
+			return "\xFFc3";
 		case 5: // set
-			return "ÿc2";
+			return "\xFFc2";
 		case 6: // rare
-			return "ÿc9";
+			return "\xFFc9";
 		case 7: // unique
-			return "ÿc4";
+			return "\xFFc4";
 		case 8: // crafted
-			return "ÿc8";
+			return "\xFFc8";
 		}
 
-		return "ÿc0";
+		return "\xFFc0";
 	},
 
 	canPick: function (unit) {

--- a/d2bs/kolbot/libs/common/Precast.js
+++ b/d2bs/kolbot/libs/common/Precast.js
@@ -117,7 +117,7 @@ var Precast = new function () {
 			break;
 		}
 
-		print("ÿc4Precastÿc0: Current " + sumCurr + ", Swap " + sumSwap);
+		print("\xFFc4Precast\xFFc0: Current " + sumCurr + ", Swap " + sumSwap);
 
 		return sumSwap > sumCurr ? Math.abs(me.weaponswitch - 1) : me.weaponswitch;
 	};

--- a/d2bs/kolbot/libs/common/Prototypes.js
+++ b/d2bs/kolbot/libs/common/Prototypes.js
@@ -685,7 +685,7 @@ Unit.prototype.getStatEx = function (id, subid) {
 
 			for (i = 0; i < temp.length; i += 1) {
 				if (temp[i].match(regex, "i")) {
-					return parseInt(temp[i].replace(/ÿc[0-9!"+<;.*]/, ""), 10);
+					return parseInt(temp[i].replace(/\xFFc[0-9!"+<;.*]/, ""), 10);
 				}
 			}
 
@@ -764,7 +764,7 @@ Unit.prototype.getStatEx = function (id, subid) {
 
 			for (i = 0; i < temp.length; i += 1) {
 				if (temp[i].match(getLocaleString(3520), "i")) {
-					return parseInt(temp[i].replace(/ÿc[0-9!"+<;.*]/, ""), 10);
+					return parseInt(temp[i].replace(/\xFFc[0-9!"+<;.*]/, ""), 10);
 				}
 			}
 
@@ -782,7 +782,7 @@ Unit.prototype.getStatEx = function (id, subid) {
 
 			for (i = 0; i < temp.length; i += 1) {
 				if (temp[i].match(getLocaleString(10038), "i")) {
-					return parseInt(temp[i].replace(/ÿc[0-9!"+<;.*]/, ""), 10);
+					return parseInt(temp[i].replace(/\xFFc[0-9!"+<;.*]/, ""), 10);
 				}
 			}
 

--- a/d2bs/kolbot/libs/common/Runewords.js
+++ b/d2bs/kolbot/libs/common/Runewords.js
@@ -131,7 +131,7 @@ var Runewords = {
 					if (NTIPAliasClassID.hasOwnProperty(Config.Runewords[i][1].replace(/\s+/g, "").toLowerCase())) {
 						Config.Runewords[i][1] = NTIPAliasClassID[Config.Runewords[i][1].replace(/\s+/g, "").toLowerCase()];
 					} else {
-						Misc.errorReport("ÿc1Invalid runewords entry:ÿc0 " + Config.Runewords[i][1]);
+						Misc.errorReport("\xFFc1Invalid runewords entry:\xFFc0 " + Config.Runewords[i][1]);
 						Config.Runewords.splice(i, 1);
 
 						i -= 1;
@@ -389,8 +389,8 @@ RuneLoop:
 				this.socketItem(items[0], items[i]);
 			}
 
-			print("ÿc4Runewords: ÿc0Made runeword: " + items[0].fname.split("\n").reverse().join(" ").replace(/ÿc[0-9!"+<;.*]/, ""));
-			D2Bot.printToConsole("Made runeword: " + items[0].fname.split("\n").reverse().join(" ").replace(/ÿc[0-9!"+<;.*]/, ""), 5);
+			print("\xFFc4Runewords: \xFFc0Made runeword: " + items[0].fname.split("\n").reverse().join(" ").replace(/\xFFc[0-9!"+<;.*]/, ""));
+			D2Bot.printToConsole("Made runeword: " + items[0].fname.split("\n").reverse().join(" ").replace(/\xFFc[0-9!"+<;.*]/, ""), 5);
 
 			if (NTIP.CheckItem(items[0], this.pickitEntries)) {
 				Misc.itemLogger("Runeword Kept", items[0]);
@@ -434,8 +434,8 @@ RuneLoop:
 					return false;
 				}
 
-				print("ÿc4Runewords: ÿc0Rerolling runeword: " + base.fname.split("\n").reverse().join(" ").replace(/ÿc[0-9!"+<;.*]/, ""));
-				D2Bot.printToConsole("Rerolling runeword: " + base.fname.split("\n").reverse().join(" ").replace(/ÿc[0-9!"+<;.*]/, ""), 5);
+				print("\xFFc4Runewords: \xFFc0Rerolling runeword: " + base.fname.split("\n").reverse().join(" ").replace(/\xFFc[0-9!"+<;.*]/, ""));
+				D2Bot.printToConsole("Rerolling runeword: " + base.fname.split("\n").reverse().join(" ").replace(/\xFFc[0-9!"+<;.*]/, ""), 5);
 				transmute();
 				delay(500);
 

--- a/d2bs/kolbot/libs/common/Storage.js
+++ b/d2bs/kolbot/libs/common/Storage.js
@@ -231,7 +231,7 @@ Loop:
 			string = "";
 
 			for (y = 0; y < this.width; y += 1) {
-				string += (this.buffer[x][y] > 0) ? "ÿc1x" : "ÿc0o";
+				string += (this.buffer[x][y] > 0) ? "\xFFc1x" : "\xFFc0o";
 			}
 
 			print(string);

--- a/d2bs/kolbot/libs/common/Town.js
+++ b/d2bs/kolbot/libs/common/Town.js
@@ -325,7 +325,7 @@ var Town = {
 				pot = this.getPotion(npc, Config.BeltColumn[i]);
 
 				if (pot) {
-					//print("ÿc2column ÿc0" + i + "ÿc2 needs ÿc0" + col[i] + " ÿc2potions");
+					//print("\xFFc2column \xFFc0" + i + "\xFFc2 needs \xFFc0" + col[i] + " \xFFc2potions");
 
 					// Shift+buy will trigger if there's no empty columns or if only the current column is empty
 					if (useShift) {
@@ -771,7 +771,7 @@ MainLoop:
 					Misc.itemLogger("Dropped", item, "fieldID");
 
 					if (Config.DroppedItemsAnnounce.Enable && Config.DroppedItemsAnnounce.Quality.indexOf(item.quality)  > -1) {
-						say("Dropped: [" + Pickit.itemQualityToName(item.quality).charAt(0).toUpperCase() + Pickit.itemQualityToName(item.quality).slice(1) + "] " + item.fname.split("\n").reverse().join(" ").replace(/ÿc[0-9!"+<;.*]/, "").trim());
+						say("Dropped: [" + Pickit.itemQualityToName(item.quality).charAt(0).toUpperCase() + Pickit.itemQualityToName(item.quality).slice(1) + "] " + item.fname.split("\n").reverse().join(" ").replace(/\xFFc[0-9!"+<;.*]/, "").trim());
 
 						if (Config.DroppedItemsAnnounce.LogToOOG && Config.DroppedItemsAnnounce.OOGQuality.indexOf(item.quality) > -1) {
 							Misc.logItem("Field Dropped", item, result.line);
@@ -895,7 +895,7 @@ CursorLoop:
 			return false;
 		}
 
-		print("ÿc4MiniShopBotÿc0: Scanning " + npc.itemcount + " items.");
+		print("\xFFc4MiniShopBot\xFFc0: Scanning " + npc.itemcount + " items.");
 
 		do {
 			if (this.ignoredItemTypes.indexOf(item.itemType) === -1) {
@@ -941,7 +941,7 @@ CursorLoop:
 					if (NTIPAliasClassID.hasOwnProperty(Config.GambleItems[i].replace(/\s+/g, "").toLowerCase())) {
 						this.gambleIds.push(NTIPAliasClassID[Config.GambleItems[i].replace(/\s+/g, "").toLowerCase()]);
 					} else {
-						Misc.errorReport("ÿc1Invalid gamble entry:ÿc0 " + Config.GambleItems[i]);
+						Misc.errorReport("\xFFc1Invalid gamble entry:\xFFc0 " + Config.GambleItems[i]);
 					}
 				} else {
 					this.gambleIds.push(Config.GambleItems[i]);
@@ -1242,8 +1242,8 @@ CursorLoop:
 						delay(me.ping * 2 + 500);
 
 						if (cubeItems[0].bodylocation === bodyLoc) {
-							print(cubeItems[0].fname.split("\n").reverse().join(" ").replace(/ÿc[0-9!"+<;.*]/, "").trim() + " successfully repaired and equipped.");
-							D2Bot.printToConsole(cubeItems[0].fname.split("\n").reverse().join(" ").replace(/ÿc[0-9!"+<;.*]/, "").trim() + " successfully repaired and equipped.", 5);
+							print(cubeItems[0].fname.split("\n").reverse().join(" ").replace(/\xFFc[0-9!"+<;.*]/, "").trim() + " successfully repaired and equipped.");
+							D2Bot.printToConsole(cubeItems[0].fname.split("\n").reverse().join(" ").replace(/\xFFc[0-9!"+<;.*]/, "").trim() + " successfully repaired and equipped.", 5);
 
 							return true;
 						}
@@ -1358,7 +1358,7 @@ CursorLoop:
 				repairAction.push("repair");
 			}
 		} else {
-			print("ÿc4Town: ÿc1Can't afford repairs.");
+			print("\xFFc4Town: \xFFc1Can't afford repairs.");
 		}
 
 		return repairAction;


### PR DESCRIPTION
Characters for message coloring (0xFF) aren't recognized properly by some of the editors. This results in broken message coloring after modifying the files. By using \xFF sequence instead, this problem doesn't happen.