### PR TITLE
Ignore items in item log

### DIFF
--- a/d2bs/kolbot/libs/common/Config.js
+++ b/d2bs/kolbot/libs/common/Config.js
@@ -184,6 +184,13 @@ var Config = {
 	ItemInfo: false,
 	ItemInfoQuality: [],
 
+	ShowLowRunes: false,
+	ShowMiddleRunes: false,
+	ShowHighRunes: true,
+	ShowLowGems: false,
+	ShowHighGems: false,
+	ShowCubingInfo: true,
+
 	Cubing: false,
 	CubeRepair: false,
 	RepairPercent: 40,

--- a/d2bs/kolbot/libs/common/Cubing.js
+++ b/d2bs/kolbot/libs/common/Cubing.js
@@ -949,7 +949,10 @@ IngredientLoop:
 				transmute();
 				delay(700 + me.ping);
 				print("\xFFc4Cubing: " + string);
-				D2Bot.printToConsole(string, 5);
+				if (Config.ShowCubingInfo) {
+					D2Bot.printToConsole(string, 5);
+				}
+
 				this.update();
 
 				items = me.findItems(-1, -1, 6);
@@ -966,7 +969,9 @@ IngredientLoop:
 							break;
 						case 1:
 							Misc.itemLogger("Cubing Kept", items[j]);
-							Misc.logItem("Cubing Kept", items[j], result.line);
+							if (Config.ShowCubingInfo) {
+								Misc.logItem("Cubing Kept", items[j], result.line);
+							}
 
 							break;
 						case 5: // Crafting System

--- a/d2bs/kolbot/libs/common/Pickit.js
+++ b/d2bs/kolbot/libs/common/Pickit.js
@@ -329,6 +329,26 @@ MainLoop:
 						break;
 					}
 
+					if (["r01", "r02", "r03", "r04", "r05", "r06", "r07", "r08", "r09", "r10", "r11", "r12", "r13", "r14"].indexOf(item.code) > -1 && !Config.ShowLowRunes) {
+						break;
+					}
+
+					if (["r15", "r16", "r17", "r18", "r19", "r20", "r21", "r22", "r23"].indexOf(item.code) > -1 && !Config.ShowMiddleRunes) {
+						break;
+					}
+
+					if (["r24", "r25", "r26", "r27", "r28", "r29", "r30", "r31", "r32", "r33"].indexOf(item.code) > -1 && !Config.ShowHighRunes) {
+						break;
+					}
+
+					if (["gcv", "gcy", "gcb", "gcg", "gcr", "gcw", "skc", "gfv", "gfy", "gfb", "gfg", "gfr", "gfw", "skf", "gsv", "gsy", "gsb", "gsg", "gsr", "gsw", "sku"].indexOf(item.code) > -1 && !Config.ShowLowGems) {
+						break;
+					}
+
+					if (["glv", "gly", "glb", "glg", "glr", "glw", "skl", "gpv", "gpy", "gpb", "gpg", "gpr", "gpw", "skz"].indexOf(item.code) > -1 && !Config.ShowHighGems) {
+						break;
+					}
+
 					Misc.logItem("Kept", item, keptLine);
 				}
 

--- a/d2bs/kolbot/libs/config/Amazon.js
+++ b/d2bs/kolbot/libs/config/Amazon.js
@@ -225,7 +225,7 @@ function LoadConfig() {
 	// Town settings
 	Config.HealHP = 50; // Go to a healer if under designated percent of life.
 	Config.HealMP = 0; // Go to a healer if under designated percent of mana.
-	Config.HealStatus = false; // Go to a healer if poisoned or cursed	
+	Config.HealStatus = false; // Go to a healer if poisoned or cursed
 	Config.UseMerc = true; // Use merc. This is ignored and always false in d2classic.
 	Config.MercWatch = false; // Instant merc revive during battle.
 
@@ -294,6 +294,14 @@ function LoadConfig() {
 	Config.FieldID = false; // Identify items in the field instead of going to town.
 	Config.DroppedItemsAnnounce.Enable = false;	// Announce Dropped Items to in-game newbs
 	Config.DroppedItemsAnnounce.Quality = []; // Quality of item to announce. See NTItemAlias.dbl for values. Example: Config.DroppedItemsAnnounce.Quality = [6, 7, 8];
+
+	// Manager Item Log
+	Config.ShowLowRunes = false; // show/stop low runes (El ÷ Dol) to appear in the item log
+	Config.ShowMiddleRunes = false; // show/stop middle runes (Hel ÷ Mal) to appear in the item log
+	Config.ShowHighRunes = true; // show/stop high runes (Ist ÷ Zod) to appear in the item log
+	Config.ShowLowGems = false; // show/stop low gems (chipped, flawed, normal) to appear in the item log
+	Config.ShowHighGems = false; // show/stop high gems (flawless, perfect) to appear in the item log
+	Config.ShowCubingInfo = true; // show/stop the cubing messages to appear on console and item log
 
 	// Repair settings
 	Config.CubeRepair = false; // Repair weapons with Ort and armor with Ral rune. Don't use it if you don't understand the risk of losing items.
@@ -414,7 +422,7 @@ function LoadConfig() {
 	Config.IAS = 0; // 0 - disable, 1 to 255 - set value of increased attack speed 
 	Config.PacketCasting = 0; // 0 = disable, 1 = packet teleport, 2 = full packet casting.
 	Config.WaypointMenu = true;
-	
+
 	// Anti-hostile config
 	Config.AntiHostile = false; // Enable anti-hostile
 	Config.HostileAction = 0; // 0 - quit immediately, 1 - quit when hostile player is sighted, 2 - attack hostile

--- a/d2bs/kolbot/libs/config/Amazon.js
+++ b/d2bs/kolbot/libs/config/Amazon.js
@@ -295,13 +295,13 @@ function LoadConfig() {
 	Config.DroppedItemsAnnounce.Enable = false;	// Announce Dropped Items to in-game newbs
 	Config.DroppedItemsAnnounce.Quality = []; // Quality of item to announce. See NTItemAlias.dbl for values. Example: Config.DroppedItemsAnnounce.Quality = [6, 7, 8];
 
-	// Manager Item Log
-	Config.ShowLowRunes = false; // show/stop low runes (El ÷ Dol) to appear in the item log
-	Config.ShowMiddleRunes = false; // show/stop middle runes (Hel ÷ Mal) to appear in the item log
-	Config.ShowHighRunes = true; // show/stop high runes (Ist ÷ Zod) to appear in the item log
-	Config.ShowLowGems = false; // show/stop low gems (chipped, flawed, normal) to appear in the item log
-	Config.ShowHighGems = false; // show/stop high gems (flawless, perfect) to appear in the item log
-	Config.ShowCubingInfo = true; // show/stop the cubing messages to appear on console and item log
+	// Manager Item Log Screen
+	Config.ShowLowRunes = false; // show/hide low runes (El ÷ Dol) on the item log screen
+	Config.ShowMiddleRunes = false; // show/hide middle runes (Hel ÷ Mal) on the item log screen
+	Config.ShowHighRunes = true; // show/hide high runes (Ist ÷ Zod) on the item log screen
+	Config.ShowLowGems = false; // show/hide low gems (chipped, flawed, normal) on the item log screen
+	Config.ShowHighGems = false; // show/hide high gems (flawless, perfect) on the item log screen
+	Config.ShowCubingInfo = true; // show/hide the cubing messages on console and item log screen
 
 	// Repair settings
 	Config.CubeRepair = false; // Repair weapons with Ort and armor with Ral rune. Don't use it if you don't understand the risk of losing items.

--- a/d2bs/kolbot/libs/config/Assassin.js
+++ b/d2bs/kolbot/libs/config/Assassin.js
@@ -295,6 +295,14 @@ function LoadConfig() {
 	Config.DroppedItemsAnnounce.Enable = false;	// Announce Dropped Items to in-game newbs
 	Config.DroppedItemsAnnounce.Quality = []; // Quality of item to announce. See NTItemAlias.dbl for values. Example: Config.DroppedItemsAnnounce.Quality = [6, 7, 8];
 
+	// Manager Item Log
+	Config.ShowLowRunes = false; // show/stop low runes (El ÷ Dol) to appear in the item log
+	Config.ShowMiddleRunes = false; // show/stop middle runes (Hel ÷ Mal) to appear in the item log
+	Config.ShowHighRunes = true; // show/stop high runes (Ist ÷ Zod) to appear in the item log
+	Config.ShowLowGems = false; // show/stop low gems (chipped, flawed, normal) to appear in the item log
+	Config.ShowHighGems = false; // show/stop high gems (flawless, perfect) to appear in the item log
+	Config.ShowCubingInfo = true; // show/stop the cubing messages to appear on console and item log
+
 	// Repair settings
 	Config.CubeRepair = false; // Repair weapons with Ort and armor with Ral rune. Don't use it if you don't understand the risk of losing items.
 	Config.RepairPercent = 40; // Durability percent of any equipped item that will trigger repairs.

--- a/d2bs/kolbot/libs/config/Assassin.js
+++ b/d2bs/kolbot/libs/config/Assassin.js
@@ -295,13 +295,13 @@ function LoadConfig() {
 	Config.DroppedItemsAnnounce.Enable = false;	// Announce Dropped Items to in-game newbs
 	Config.DroppedItemsAnnounce.Quality = []; // Quality of item to announce. See NTItemAlias.dbl for values. Example: Config.DroppedItemsAnnounce.Quality = [6, 7, 8];
 
-	// Manager Item Log
-	Config.ShowLowRunes = false; // show/stop low runes (El ÷ Dol) to appear in the item log
-	Config.ShowMiddleRunes = false; // show/stop middle runes (Hel ÷ Mal) to appear in the item log
-	Config.ShowHighRunes = true; // show/stop high runes (Ist ÷ Zod) to appear in the item log
-	Config.ShowLowGems = false; // show/stop low gems (chipped, flawed, normal) to appear in the item log
-	Config.ShowHighGems = false; // show/stop high gems (flawless, perfect) to appear in the item log
-	Config.ShowCubingInfo = true; // show/stop the cubing messages to appear on console and item log
+	// Manager Item Log Screen
+	Config.ShowLowRunes = false; // show/hide low runes (El ÷ Dol) on the item log screen
+	Config.ShowMiddleRunes = false; // show/hide middle runes (Hel ÷ Mal) on the item log screen
+	Config.ShowHighRunes = true; // show/hide high runes (Ist ÷ Zod) on the item log screen
+	Config.ShowLowGems = false; // show/hide low gems (chipped, flawed, normal) on the item log screen
+	Config.ShowHighGems = false; // show/hide high gems (flawless, perfect) on the item log screen
+	Config.ShowCubingInfo = true; // show/hide the cubing messages on console and item log screen
 
 	// Repair settings
 	Config.CubeRepair = false; // Repair weapons with Ort and armor with Ral rune. Don't use it if you don't understand the risk of losing items.

--- a/d2bs/kolbot/libs/config/Barbarian.js
+++ b/d2bs/kolbot/libs/config/Barbarian.js
@@ -295,6 +295,14 @@ function LoadConfig() {
 	Config.DroppedItemsAnnounce.Enable = false;	// Announce Dropped Items to in-game newbs
 	Config.DroppedItemsAnnounce.Quality = []; // Quality of item to announce. See NTItemAlias.dbl for values. Example: Config.DroppedItemsAnnounce.Quality = [6, 7, 8];
 
+	// Manager Item Log
+	Config.ShowLowRunes = false; // show/stop low runes (El ÷ Dol) to appear in the item log
+	Config.ShowMiddleRunes = false; // show/stop middle runes (Hel ÷ Mal) to appear in the item log
+	Config.ShowHighRunes = true; // show/stop high runes (Ist ÷ Zod) to appear in the item log
+	Config.ShowLowGems = false; // show/stop low gems (chipped, flawed, normal) to appear in the item log
+	Config.ShowHighGems = false; // show/stop high gems (flawless, perfect) to appear in the item log
+	Config.ShowCubingInfo = true; // show/stop the cubing messages to appear on console and item log
+
 	// Repair settings
 	Config.CubeRepair = false; // Repair weapons with Ort and armor with Ral rune. Don't use it if you don't understand the risk of losing items.
 	Config.RepairPercent = 40; // Durability percent of any equipped item that will trigger repairs.

--- a/d2bs/kolbot/libs/config/Barbarian.js
+++ b/d2bs/kolbot/libs/config/Barbarian.js
@@ -295,13 +295,13 @@ function LoadConfig() {
 	Config.DroppedItemsAnnounce.Enable = false;	// Announce Dropped Items to in-game newbs
 	Config.DroppedItemsAnnounce.Quality = []; // Quality of item to announce. See NTItemAlias.dbl for values. Example: Config.DroppedItemsAnnounce.Quality = [6, 7, 8];
 
-	// Manager Item Log
-	Config.ShowLowRunes = false; // show/stop low runes (El ÷ Dol) to appear in the item log
-	Config.ShowMiddleRunes = false; // show/stop middle runes (Hel ÷ Mal) to appear in the item log
-	Config.ShowHighRunes = true; // show/stop high runes (Ist ÷ Zod) to appear in the item log
-	Config.ShowLowGems = false; // show/stop low gems (chipped, flawed, normal) to appear in the item log
-	Config.ShowHighGems = false; // show/stop high gems (flawless, perfect) to appear in the item log
-	Config.ShowCubingInfo = true; // show/stop the cubing messages to appear on console and item log
+	// Manager Item Log Screen
+	Config.ShowLowRunes = false; // show/hide low runes (El ÷ Dol) on the item log screen
+	Config.ShowMiddleRunes = false; // show/hide middle runes (Hel ÷ Mal) on the item log screen
+	Config.ShowHighRunes = true; // show/hide high runes (Ist ÷ Zod) on the item log screen
+	Config.ShowLowGems = false; // show/hide low gems (chipped, flawed, normal) on the item log screen
+	Config.ShowHighGems = false; // show/hide high gems (flawless, perfect) on the item log screen
+	Config.ShowCubingInfo = true; // show/hide the cubing messages on console and item log screen
 
 	// Repair settings
 	Config.CubeRepair = false; // Repair weapons with Ort and armor with Ral rune. Don't use it if you don't understand the risk of losing items.

--- a/d2bs/kolbot/libs/config/Druid.js
+++ b/d2bs/kolbot/libs/config/Druid.js
@@ -295,6 +295,14 @@ function LoadConfig() {
 	Config.DroppedItemsAnnounce.Enable = false;	// Announce Dropped Items to in-game newbs
 	Config.DroppedItemsAnnounce.Quality = []; // Quality of item to announce. See NTItemAlias.dbl for values. Example: Config.DroppedItemsAnnounce.Quality = [6, 7, 8];
 
+	// Manager Item Log
+	Config.ShowLowRunes = false; // show/stop low runes (El ÷ Dol) to appear in the item log
+	Config.ShowMiddleRunes = false; // show/stop middle runes (Hel ÷ Mal) to appear in the item log
+	Config.ShowHighRunes = true; // show/stop high runes (Ist ÷ Zod) to appear in the item log
+	Config.ShowLowGems = false; // show/stop low gems (chipped, flawed, normal) to appear in the item log
+	Config.ShowHighGems = false; // show/stop high gems (flawless, perfect) to appear in the item log
+	Config.ShowCubingInfo = true; // show/stop the cubing messages to appear on console and item log
+
 	// Repair settings
 	Config.CubeRepair = false; // Repair weapons with Ort and armor with Ral rune. Don't use it if you don't understand the risk of losing items.
 	Config.RepairPercent = 40; // Durability percent of any equipped item that will trigger repairs.

--- a/d2bs/kolbot/libs/config/Druid.js
+++ b/d2bs/kolbot/libs/config/Druid.js
@@ -295,13 +295,13 @@ function LoadConfig() {
 	Config.DroppedItemsAnnounce.Enable = false;	// Announce Dropped Items to in-game newbs
 	Config.DroppedItemsAnnounce.Quality = []; // Quality of item to announce. See NTItemAlias.dbl for values. Example: Config.DroppedItemsAnnounce.Quality = [6, 7, 8];
 
-	// Manager Item Log
-	Config.ShowLowRunes = false; // show/stop low runes (El ÷ Dol) to appear in the item log
-	Config.ShowMiddleRunes = false; // show/stop middle runes (Hel ÷ Mal) to appear in the item log
-	Config.ShowHighRunes = true; // show/stop high runes (Ist ÷ Zod) to appear in the item log
-	Config.ShowLowGems = false; // show/stop low gems (chipped, flawed, normal) to appear in the item log
-	Config.ShowHighGems = false; // show/stop high gems (flawless, perfect) to appear in the item log
-	Config.ShowCubingInfo = true; // show/stop the cubing messages to appear on console and item log
+	// Manager Item Log Screen
+	Config.ShowLowRunes = false; // show/hide low runes (El ÷ Dol) on the item log screen
+	Config.ShowMiddleRunes = false; // show/hide middle runes (Hel ÷ Mal) on the item log screen
+	Config.ShowHighRunes = true; // show/hide high runes (Ist ÷ Zod) on the item log screen
+	Config.ShowLowGems = false; // show/hide low gems (chipped, flawed, normal) on the item log screen
+	Config.ShowHighGems = false; // show/hide high gems (flawless, perfect) on the item log screen
+	Config.ShowCubingInfo = true; // show/hide the cubing messages on console and item log screen
 
 	// Repair settings
 	Config.CubeRepair = false; // Repair weapons with Ort and armor with Ral rune. Don't use it if you don't understand the risk of losing items.

--- a/d2bs/kolbot/libs/config/Necromancer.js
+++ b/d2bs/kolbot/libs/config/Necromancer.js
@@ -295,13 +295,13 @@ function LoadConfig() {
 	Config.DroppedItemsAnnounce.Enable = false;	// Announce Dropped Items to in-game newbs
 	Config.DroppedItemsAnnounce.Quality = []; // Quality of item to announce. See NTItemAlias.dbl for values. Example: Config.DroppedItemsAnnounce.Quality = [6, 7, 8];
 
-	// Manager Item Log
-	Config.ShowLowRunes = false; // show/stop low runes (El ÷ Dol) to appear in the item log
-	Config.ShowMiddleRunes = false; // show/stop middle runes (Hel ÷ Mal) to appear in the item log
-	Config.ShowHighRunes = true; // show/stop high runes (Ist ÷ Zod) to appear in the item log
-	Config.ShowLowGems = false; // show/stop low gems (chipped, flawed, normal) to appear in the item log
-	Config.ShowHighGems = false; // show/stop high gems (flawless, perfect) to appear in the item log
-	Config.ShowCubingInfo = true; // show/stop the cubing messages to appear on console and item log
+	// Manager Item Log Screen
+	Config.ShowLowRunes = false; // show/hide low runes (El ÷ Dol) on the item log screen
+	Config.ShowMiddleRunes = false; // show/hide middle runes (Hel ÷ Mal) on the item log screen
+	Config.ShowHighRunes = true; // show/hide high runes (Ist ÷ Zod) on the item log screen
+	Config.ShowLowGems = false; // show/hide low gems (chipped, flawed, normal) on the item log screen
+	Config.ShowHighGems = false; // show/hide high gems (flawless, perfect) on the item log screen
+	Config.ShowCubingInfo = true; // show/hide the cubing messages on console and item log screen
 
 	// Repair settings
 	Config.CubeRepair = false; // Repair weapons with Ort and armor with Ral rune. Don't use it if you don't understand the risk of losing items.

--- a/d2bs/kolbot/libs/config/Necromancer.js
+++ b/d2bs/kolbot/libs/config/Necromancer.js
@@ -295,6 +295,14 @@ function LoadConfig() {
 	Config.DroppedItemsAnnounce.Enable = false;	// Announce Dropped Items to in-game newbs
 	Config.DroppedItemsAnnounce.Quality = []; // Quality of item to announce. See NTItemAlias.dbl for values. Example: Config.DroppedItemsAnnounce.Quality = [6, 7, 8];
 
+	// Manager Item Log
+	Config.ShowLowRunes = false; // show/stop low runes (El ÷ Dol) to appear in the item log
+	Config.ShowMiddleRunes = false; // show/stop middle runes (Hel ÷ Mal) to appear in the item log
+	Config.ShowHighRunes = true; // show/stop high runes (Ist ÷ Zod) to appear in the item log
+	Config.ShowLowGems = false; // show/stop low gems (chipped, flawed, normal) to appear in the item log
+	Config.ShowHighGems = false; // show/stop high gems (flawless, perfect) to appear in the item log
+	Config.ShowCubingInfo = true; // show/stop the cubing messages to appear on console and item log
+
 	// Repair settings
 	Config.CubeRepair = false; // Repair weapons with Ort and armor with Ral rune. Don't use it if you don't understand the risk of losing items.
 	Config.RepairPercent = 40; // Durability percent of any equipped item that will trigger repairs.
@@ -414,7 +422,7 @@ function LoadConfig() {
 	Config.IAS = 0; // 0 - disable, 1 to 255 - set value of increased attack speed 
 	Config.PacketCasting = 0; // 0 = disable, 1 = packet teleport, 2 = full packet casting.
 	Config.WaypointMenu = true;
-	
+
 	// Anti-hostile config
 	Config.AntiHostile = false; // Enable anti-hostile
 	Config.HostileAction = 0; // 0 - quit immediately, 1 - quit when hostile player is sighted, 2 - attack hostile

--- a/d2bs/kolbot/libs/config/Paladin.js
+++ b/d2bs/kolbot/libs/config/Paladin.js
@@ -295,6 +295,14 @@ function LoadConfig() {
 	Config.DroppedItemsAnnounce.Enable = false;	// Announce Dropped Items to in-game newbs
 	Config.DroppedItemsAnnounce.Quality = []; // Quality of item to announce. See NTItemAlias.dbl for values. Example: Config.DroppedItemsAnnounce.Quality = [6, 7, 8];
 
+	// Manager Item Log
+	Config.ShowLowRunes = false; // show/stop low runes (El ÷ Dol) to appear in the item log
+	Config.ShowMiddleRunes = false; // show/stop middle runes (Hel ÷ Mal) to appear in the item log
+	Config.ShowHighRunes = true; // show/stop high runes (Ist ÷ Zod) to appear in the item log
+	Config.ShowLowGems = false; // show/stop low gems (chipped, flawed, normal) to appear in the item log
+	Config.ShowHighGems = false; // show/stop high gems (flawless, perfect) to appear in the item log
+	Config.ShowCubingInfo = true; // show/stop the cubing messages to appear on console and item log
+
 	// Repair settings
 	Config.CubeRepair = false; // Repair weapons with Ort and armor with Ral rune. Don't use it if you don't understand the risk of losing items.
 	Config.RepairPercent = 40; // Durability percent of any equipped item that will trigger repairs.

--- a/d2bs/kolbot/libs/config/Paladin.js
+++ b/d2bs/kolbot/libs/config/Paladin.js
@@ -295,13 +295,13 @@ function LoadConfig() {
 	Config.DroppedItemsAnnounce.Enable = false;	// Announce Dropped Items to in-game newbs
 	Config.DroppedItemsAnnounce.Quality = []; // Quality of item to announce. See NTItemAlias.dbl for values. Example: Config.DroppedItemsAnnounce.Quality = [6, 7, 8];
 
-	// Manager Item Log
-	Config.ShowLowRunes = false; // show/stop low runes (El ÷ Dol) to appear in the item log
-	Config.ShowMiddleRunes = false; // show/stop middle runes (Hel ÷ Mal) to appear in the item log
-	Config.ShowHighRunes = true; // show/stop high runes (Ist ÷ Zod) to appear in the item log
-	Config.ShowLowGems = false; // show/stop low gems (chipped, flawed, normal) to appear in the item log
-	Config.ShowHighGems = false; // show/stop high gems (flawless, perfect) to appear in the item log
-	Config.ShowCubingInfo = true; // show/stop the cubing messages to appear on console and item log
+	// Manager Item Log Screen
+	Config.ShowLowRunes = false; // show/hide low runes (El ÷ Dol) on the item log screen
+	Config.ShowMiddleRunes = false; // show/hide middle runes (Hel ÷ Mal) on the item log screen
+	Config.ShowHighRunes = true; // show/hide high runes (Ist ÷ Zod) on the item log screen
+	Config.ShowLowGems = false; // show/hide low gems (chipped, flawed, normal) on the item log screen
+	Config.ShowHighGems = false; // show/hide high gems (flawless, perfect) on the item log screen
+	Config.ShowCubingInfo = true; // show/hide the cubing messages on console and item log screen
 
 	// Repair settings
 	Config.CubeRepair = false; // Repair weapons with Ort and armor with Ral rune. Don't use it if you don't understand the risk of losing items.

--- a/d2bs/kolbot/libs/config/Sorceress.js
+++ b/d2bs/kolbot/libs/config/Sorceress.js
@@ -295,6 +295,14 @@ function LoadConfig() {
 	Config.DroppedItemsAnnounce.Enable = false;	// Announce Dropped Items to in-game newbs
 	Config.DroppedItemsAnnounce.Quality = []; // Quality of item to announce. See NTItemAlias.dbl for values. Example: Config.DroppedItemsAnnounce.Quality = [6, 7, 8];
 
+	// Manager Item Log
+	Config.ShowLowRunes = false; // show/stop low runes (El ÷ Dol) to appear in the item log
+	Config.ShowMiddleRunes = false; // show/stop middle runes (Hel ÷ Mal) to appear in the item log
+	Config.ShowHighRunes = true; // show/stop high runes (Ist ÷ Zod) to appear in the item log
+	Config.ShowLowGems = false; // show/stop low gems (chipped, flawed, normal) to appear in the item log
+	Config.ShowHighGems = false; // show/stop high gems (flawless, perfect) to appear in the item log
+	Config.ShowCubingInfo = true; // show/stop the cubing messages to appear on console and item log
+
 	// Repair settings
 	Config.CubeRepair = false; // Repair weapons with Ort and armor with Ral rune. Don't use it if you don't understand the risk of losing items.
 	Config.RepairPercent = 40; // Durability percent of any equipped item that will trigger repairs.

--- a/d2bs/kolbot/libs/config/Sorceress.js
+++ b/d2bs/kolbot/libs/config/Sorceress.js
@@ -295,13 +295,13 @@ function LoadConfig() {
 	Config.DroppedItemsAnnounce.Enable = false;	// Announce Dropped Items to in-game newbs
 	Config.DroppedItemsAnnounce.Quality = []; // Quality of item to announce. See NTItemAlias.dbl for values. Example: Config.DroppedItemsAnnounce.Quality = [6, 7, 8];
 
-	// Manager Item Log
-	Config.ShowLowRunes = false; // show/stop low runes (El ÷ Dol) to appear in the item log
-	Config.ShowMiddleRunes = false; // show/stop middle runes (Hel ÷ Mal) to appear in the item log
-	Config.ShowHighRunes = true; // show/stop high runes (Ist ÷ Zod) to appear in the item log
-	Config.ShowLowGems = false; // show/stop low gems (chipped, flawed, normal) to appear in the item log
-	Config.ShowHighGems = false; // show/stop high gems (flawless, perfect) to appear in the item log
-	Config.ShowCubingInfo = true; // show/stop the cubing messages to appear on console and item log
+	// Manager Item Log Screen
+	Config.ShowLowRunes = false; // show/hide low runes (El ÷ Dol) on the item log screen
+	Config.ShowMiddleRunes = false; // show/hide middle runes (Hel ÷ Mal) on the item log screen
+	Config.ShowHighRunes = true; // show/hide high runes (Ist ÷ Zod) on the item log screen
+	Config.ShowLowGems = false; // show/hide low gems (chipped, flawed, normal) on the item log screen
+	Config.ShowHighGems = false; // show/hide high gems (flawless, perfect) on the item log screen
+	Config.ShowCubingInfo = true; // show/hide the cubing messages on console and item log screen
 
 	// Repair settings
 	Config.CubeRepair = false; // Repair weapons with Ort and armor with Ral rune. Don't use it if you don't understand the risk of losing items.


### PR DESCRIPTION
customized options to show/hide messages about picking runes and gems in manager item log.
customized option to show/hide the cubing messages on console and item log.