### PR TITLE
Added "StartWalking" feature to Tristram and Diablo scripts

### DIFF
--- a/d2bs/kolbot/libs/bots/Diablo.js
+++ b/d2bs/kolbot/libs/bots/Diablo.js
@@ -420,7 +420,8 @@ function Diablo() {
 	this.starToSeisB = [7781, 5259, 7805, 5258, 7802, 5237, 7776, 5228, 7811, 5218, 7807, 5194, 7779, 5193, 7774, 5160, 7803, 5154];
 	this.starToInfA = [7809, 5268, 7834, 5306, 7852, 5280, 7852, 5310, 7869, 5294, 7895, 5295, 7919, 5290];
 	this.starToInfB = [7809, 5268, 7834, 5306, 7852, 5280, 7852, 5310, 7869, 5294, 7895, 5274, 7927, 5275, 7932, 5297, 7923, 5313];
-
+	this.OriginalTeleport = Pather.teleport;
+	
 	// start
 	Town.doChores();
 	Pather.useWaypoint(Config.RandomPrecast ? "random" : 107);
@@ -443,6 +444,9 @@ function Diablo() {
 		if (Config.PublicMode) {
 			Pather.makePortal();
 			say(Config.Diablo.EntranceTP);
+			if (Config.Diablo.StartWalking) {
+				Pather.teleport = false;
+			}
 		}
 
 		Pather.moveTo(7790, 5544);
@@ -459,6 +463,9 @@ function Diablo() {
 	if (Config.PublicMode) {
 		Pather.makePortal();
 		say(Config.Diablo.StarTP);
+		if (Config.Diablo.StartWalking) {
+			Pather.teleport = false;
+		}
 	}
 
 	Attack.clear(30, 0, false, this.sort);
@@ -487,5 +494,7 @@ function Diablo() {
 	Attack.kill(243); // Diablo
 	Pickit.pickItems();
 
+	Pather.teleport = this.OriginalTeleport;
+	
 	return true;
 }

--- a/d2bs/kolbot/libs/bots/Diablo.js
+++ b/d2bs/kolbot/libs/bots/Diablo.js
@@ -420,7 +420,7 @@ function Diablo() {
 	this.starToSeisB = [7781, 5259, 7805, 5258, 7802, 5237, 7776, 5228, 7811, 5218, 7807, 5194, 7779, 5193, 7774, 5160, 7803, 5154];
 	this.starToInfA = [7809, 5268, 7834, 5306, 7852, 5280, 7852, 5310, 7869, 5294, 7895, 5295, 7919, 5290];
 	this.starToInfB = [7809, 5268, 7834, 5306, 7852, 5280, 7852, 5310, 7869, 5294, 7895, 5274, 7927, 5275, 7932, 5297, 7923, 5313];
-	this.OriginalTeleport = Pather.teleport;
+	Pather._teleport = Pather.teleport;
 	
 	// start
 	Town.doChores();
@@ -444,9 +444,7 @@ function Diablo() {
 		if (Config.PublicMode) {
 			Pather.makePortal();
 			say(Config.Diablo.EntranceTP);
-			if (Config.Diablo.StartWalking) {
-				Pather.teleport = false;
-			}
+			Pather.teleport = !Config.Diablo.WalkClear && Pather._teleport;
 		}
 
 		Pather.moveTo(7790, 5544);
@@ -463,9 +461,7 @@ function Diablo() {
 	if (Config.PublicMode) {
 		Pather.makePortal();
 		say(Config.Diablo.StarTP);
-		if (Config.Diablo.StartWalking) {
-			Pather.teleport = false;
-		}
+		Pather.teleport = !Config.Diablo.WalkClear && Pather._teleport;
 	}
 
 	Attack.clear(30, 0, false, this.sort);
@@ -494,7 +490,7 @@ function Diablo() {
 	Attack.kill(243); // Diablo
 	Pickit.pickItems();
 
-	Pather.teleport = this.OriginalTeleport;
+	Pather.teleport = Pather._teleport;
 	
 	return true;
 }

--- a/d2bs/kolbot/libs/bots/Tristram.js
+++ b/d2bs/kolbot/libs/bots/Tristram.js
@@ -38,6 +38,8 @@ function Tristram() {
 		me.cancel();
 	}
 
+	this.OriginalTeleport = Pather.teleport;
+	
 	Town.doChores();
 	Pather.useWaypoint(4);
 	Precast.doPrecast(true);
@@ -70,6 +72,9 @@ function Tristram() {
 	if (Config.Tristram.PortalLeech) {
 		Pather.makePortal();
 		delay(1000);
+		if (Config.Tristram.StartWalking) {
+			Pather.teleport = false;
+		}
 	}
 
 	gibbet = getUnit(2, 26);
@@ -87,6 +92,8 @@ function Tristram() {
 	} else {
 		Attack.clearLevel(Config.ClearType);
 	}
+	
+	Pather.teleport = this.OriginalTeleport;
 
 	return true;
 }

--- a/d2bs/kolbot/libs/bots/Tristram.js
+++ b/d2bs/kolbot/libs/bots/Tristram.js
@@ -38,7 +38,7 @@ function Tristram() {
 		me.cancel();
 	}
 
-	this.OriginalTeleport = Pather.teleport;
+	Pather._teleport = Pather.teleport;
 	
 	Town.doChores();
 	Pather.useWaypoint(4);
@@ -72,9 +72,7 @@ function Tristram() {
 	if (Config.Tristram.PortalLeech) {
 		Pather.makePortal();
 		delay(1000);
-		if (Config.Tristram.StartWalking) {
-			Pather.teleport = false;
-		}
+		Pather.teleport = !Config.Tristram.WalkClear && Pather._teleport;
 	}
 
 	gibbet = getUnit(2, 26);
@@ -93,7 +91,7 @@ function Tristram() {
 		Attack.clearLevel(Config.ClearType);
 	}
 	
-	Pather.teleport = this.OriginalTeleport;
+	Pather.teleport = Pather._teleport;
 
 	return true;
 }

--- a/d2bs/kolbot/libs/common/Config.js
+++ b/d2bs/kolbot/libs/common/Config.js
@@ -389,7 +389,8 @@ var Config = {
 		SealWarning: "Leave the seals alone!",
 		EntranceTP: "Entrance TP up",
 		StarTP: "Star TP up",
-		DiabloMsg: "Diablo"
+		DiabloMsg: "Diablo",
+		StartWalking: false
 	},
 	DiabloHelper: {
 		Wait: 120,
@@ -457,7 +458,8 @@ var Config = {
 		Wait: 120
 	},
 	Tristram: {
-		PortalLeech: false
+		PortalLeech: false,
+		StartWalking: false
 	},
 	Travincal: {
 		PortalLeech: false

--- a/d2bs/kolbot/libs/common/Config.js
+++ b/d2bs/kolbot/libs/common/Config.js
@@ -390,7 +390,7 @@ var Config = {
 		EntranceTP: "Entrance TP up",
 		StarTP: "Star TP up",
 		DiabloMsg: "Diablo",
-		StartWalking: false
+		WalkClear: false
 	},
 	DiabloHelper: {
 		Wait: 120,
@@ -459,7 +459,7 @@ var Config = {
 	},
 	Tristram: {
 		PortalLeech: false,
-		StartWalking: false
+		WalkClear: false
 	},
 	Travincal: {
 		PortalLeech: false

--- a/d2bs/kolbot/libs/config/Amazon.js
+++ b/d2bs/kolbot/libs/config/Amazon.js
@@ -38,6 +38,7 @@ function LoadConfig() {
 	Scripts.UndergroundPassage = false;
 	Scripts.Coldcrow = false;
 	Scripts.Tristram = false;
+		Config.Tristram.WalkClear = false; // Disable teleport while clearing to protect leechers
 		Config.Tristram.PortalLeech = false; // Set to true to open a portal for leechers.
 	Scripts.Pit = false;
 		Config.Pit.ClearPit1 = true;
@@ -81,6 +82,7 @@ function LoadConfig() {
 	Scripts.Vizier = false; // Intended for classic sorc, kills Vizier only.
 	Scripts.FastDiablo = false;
 	Scripts.Diablo = false;
+		Config.Diablo.WalkClear = false; // Disable teleport while clearing to protect leechers
 		Config.Diablo.Entrance = true; // Start from entrance
 		Config.Diablo.SealWarning = "Leave the seals alone!";
 		Config.Diablo.EntranceTP = "Entrance TP up";

--- a/d2bs/kolbot/libs/config/Assassin.js
+++ b/d2bs/kolbot/libs/config/Assassin.js
@@ -38,6 +38,7 @@ function LoadConfig() {
 	Scripts.UndergroundPassage = false;
 	Scripts.Coldcrow = false;
 	Scripts.Tristram = false;
+		Config.Tristram.WalkClear = false; // Disable teleport while clearing to protect leechers
 		Config.Tristram.PortalLeech = false; // Set to true to open a portal for leechers.
 	Scripts.Pit = false;
 		Config.Pit.ClearPit1 = true;
@@ -81,6 +82,7 @@ function LoadConfig() {
 	Scripts.Vizier = false; // Intended for classic sorc, kills Vizier only.
 	Scripts.FastDiablo = false;
 	Scripts.Diablo = false;
+		Config.Diablo.WalkClear = false; // Disable teleport while clearing to protect leechers
 		Config.Diablo.Entrance = true; // Start from entrance
 		Config.Diablo.SealWarning = "Leave the seals alone!";
 		Config.Diablo.EntranceTP = "Entrance TP up";

--- a/d2bs/kolbot/libs/config/Barbarian.js
+++ b/d2bs/kolbot/libs/config/Barbarian.js
@@ -38,6 +38,7 @@ function LoadConfig() {
 	Scripts.UndergroundPassage = false;
 	Scripts.Coldcrow = false;
 	Scripts.Tristram = false;
+		Config.Tristram.WalkClear = false; // Disable teleport while clearing to protect leechers
 		Config.Tristram.PortalLeech = false; // Set to true to open a portal for leechers.
 	Scripts.Pit = false;
 		Config.Pit.ClearPit1 = true;
@@ -81,6 +82,7 @@ function LoadConfig() {
 	Scripts.Vizier = false; // Intended for classic sorc, kills Vizier only.
 	Scripts.FastDiablo = false;
 	Scripts.Diablo = false;
+		Config.Diablo.WalkClear = false; // Disable teleport while clearing to protect leechers
 		Config.Diablo.Entrance = true; // Start from entrance
 		Config.Diablo.SealWarning = "Leave the seals alone!";
 		Config.Diablo.EntranceTP = "Entrance TP up";

--- a/d2bs/kolbot/libs/config/Druid.js
+++ b/d2bs/kolbot/libs/config/Druid.js
@@ -38,6 +38,7 @@ function LoadConfig() {
 	Scripts.UndergroundPassage = false;
 	Scripts.Coldcrow = false;
 	Scripts.Tristram = false;
+		Config.Tristram.WalkClear = false; // Disable teleport while clearing to protect leechers
 		Config.Tristram.PortalLeech = false; // Set to true to open a portal for leechers.
 	Scripts.Pit = false;
 		Config.Pit.ClearPit1 = true;
@@ -81,6 +82,7 @@ function LoadConfig() {
 	Scripts.Vizier = false; // Intended for classic sorc, kills Vizier only.
 	Scripts.FastDiablo = false;
 	Scripts.Diablo = false;
+		Config.Diablo.WalkClear = false; // Disable teleport while clearing to protect leechers
 		Config.Diablo.Entrance = true; // Start from entrance
 		Config.Diablo.SealWarning = "Leave the seals alone!";
 		Config.Diablo.EntranceTP = "Entrance TP up";

--- a/d2bs/kolbot/libs/config/Necromancer.js
+++ b/d2bs/kolbot/libs/config/Necromancer.js
@@ -38,6 +38,7 @@ function LoadConfig() {
 	Scripts.UndergroundPassage = false;
 	Scripts.Coldcrow = false;
 	Scripts.Tristram = false;
+		Config.Tristram.WalkClear = false; // Disable teleport while clearing to protect leechers
 		Config.Tristram.PortalLeech = false; // Set to true to open a portal for leechers.
 	Scripts.Pit = false;
 		Config.Pit.ClearPit1 = true;
@@ -81,6 +82,7 @@ function LoadConfig() {
 	Scripts.Vizier = false; // Intended for classic sorc, kills Vizier only.
 	Scripts.FastDiablo = false;
 	Scripts.Diablo = false;
+		Config.Diablo.WalkClear = false; // Disable teleport while clearing to protect leechers
 		Config.Diablo.Entrance = true; // Start from entrance
 		Config.Diablo.SealWarning = "Leave the seals alone!";
 		Config.Diablo.EntranceTP = "Entrance TP up";

--- a/d2bs/kolbot/libs/config/Paladin.js
+++ b/d2bs/kolbot/libs/config/Paladin.js
@@ -38,6 +38,7 @@ function LoadConfig() {
 	Scripts.UndergroundPassage = false;
 	Scripts.Coldcrow = false;
 	Scripts.Tristram = false;
+		Config.Tristram.WalkClear = false; // Disable teleport while clearing to protect leechers
 		Config.Tristram.PortalLeech = false; // Set to true to open a portal for leechers.
 	Scripts.Pit = false;
 		Config.Pit.ClearPit1 = true;
@@ -81,6 +82,7 @@ function LoadConfig() {
 	Scripts.Vizier = false; // Intended for classic sorc, kills Vizier only.
 	Scripts.FastDiablo = false;
 	Scripts.Diablo = false;
+		Config.Diablo.WalkClear = false; // Disable teleport while clearing to protect leechers
 		Config.Diablo.Entrance = true; // Start from entrance
 		Config.Diablo.SealWarning = "Leave the seals alone!";
 		Config.Diablo.EntranceTP = "Entrance TP up";

--- a/d2bs/kolbot/libs/config/Sorceress.js
+++ b/d2bs/kolbot/libs/config/Sorceress.js
@@ -38,6 +38,7 @@ function LoadConfig() {
 	Scripts.UndergroundPassage = false;
 	Scripts.Coldcrow = false;
 	Scripts.Tristram = false;
+		Config.Tristram.WalkClear = false; // Disable teleport while clearing to protect leechers
 		Config.Tristram.PortalLeech = false; // Set to true to open a portal for leechers.
 	Scripts.Pit = false;
 		Config.Pit.ClearPit1 = true;
@@ -81,6 +82,7 @@ function LoadConfig() {
 	Scripts.Vizier = false; // Intended for classic sorc, kills Vizier only.
 	Scripts.FastDiablo = false;
 	Scripts.Diablo = false;
+		Config.Diablo.WalkClear = false; // Disable teleport while clearing to protect leechers
 		Config.Diablo.Entrance = true; // Start from entrance
 		Config.Diablo.SealWarning = "Leave the seals alone!";
 		Config.Diablo.EntranceTP = "Entrance TP up";


### PR DESCRIPTION
This feature temporarily disables teleport for scripts that are commonly used to level people. Using StartWalking in the Diablo script while Leechers use Wakka significantly reduces the number of times leechers need to Chicken to a stray monster.