### PR TITLE
added lines for missing runes

### DIFF
--- a/d2bs/kolbot/pickit/kolton.nip
+++ b/d2bs/kolbot/pickit/kolton.nip
@@ -634,6 +634,9 @@
 //[name] == korune # # [MaxQuantity] == 1
 //[name] == falrune
 //[name] == lemrune # # [MaxQuantity] == 1
+//[name] == pulrune # # [MaxQuantity] == 1
+//[name] == umrune # # [MaxQuantity] == 1
+//[name] == malrune # # [MaxQuantity] == 1
 
 [name] >= istrune && [name] <= zodrune
 


### PR DESCRIPTION
As a new-ish user, found it odd that the default pickit script did not have a place for pul, um, and mal runes. Added commented lines for these runes just like all other lower runes for easy editing by other users as needed.