### PR TITLE
Add AutoSkill and AutoStat function

### DIFF
--- a/d2bs/kolbot/default.dbj
+++ b/d2bs/kolbot/default.dbj
@@ -23,6 +23,8 @@ include("common/Prototypes.js");
 include("common/Runewords.js");
 include("common/Storage.js");
 include("common/Town.js");
+include("common/AutoSkill.js");
+include("common/AutoStat.js");
 
 function main() {
 	D2Bot.init(); // Get D2Bot# handle
@@ -182,6 +184,15 @@ function main() {
 	// Next game = drop keys
 	if (TorchSystem.keyCheck()) {
 		scriptBroadcast("torch");
+	}
+
+	// Auto skill and stat
+	if (Config.AutoSkill.Enabled) {
+		AutoSkill.init(Config.AutoSkill.Build, Config.AutoSkill.Save);
+	}
+
+	if (Config.AutoStat.Enabled) {
+		AutoStat.init(Config.AutoStat.Build, Config.AutoStat.Save, Config.AutoStat.BlockChance, Config.AutoStat.UseBulk);
 	}
 
 	// Go

--- a/d2bs/kolbot/default.dbj
+++ b/d2bs/kolbot/default.dbj
@@ -23,8 +23,6 @@ include("common/Prototypes.js");
 include("common/Runewords.js");
 include("common/Storage.js");
 include("common/Town.js");
-include("common/AutoSkill.js");
-include("common/AutoStat.js");
 
 function main() {
 	D2Bot.init(); // Get D2Bot# handle
@@ -187,11 +185,11 @@ function main() {
 	}
 
 	// Auto skill and stat
-	if (Config.AutoSkill.Enabled) {
+	if (Config.AutoSkill.Enabled && include("common/AutoSkill.js")) {
 		AutoSkill.init(Config.AutoSkill.Build, Config.AutoSkill.Save);
 	}
 
-	if (Config.AutoStat.Enabled) {
+	if (Config.AutoStat.Enabled && include("common/AutoStat.js")) {
 		AutoStat.init(Config.AutoStat.Build, Config.AutoStat.Save, Config.AutoStat.BlockChance, Config.AutoStat.UseBulk);
 	}
 

--- a/d2bs/kolbot/libs/common/AutoSkill.js
+++ b/d2bs/kolbot/libs/common/AutoSkill.js
@@ -1,0 +1,149 @@
+/**
+*	@filename	AutoSkill.js
+*	@author		Original work by Nad42, edited by IMBA
+*	@desc		Automatically allocate skill points and its pre-requisites if necessary
+*/
+
+var AutoSkill = new function () {
+	this.skillBuildOrder = [];
+	this.save = 0;
+
+	/*	skillBuildOrder - array of skill points to spend in order
+		save - number of skill points that will not be spent and saved
+
+		skillBuildOrder Settings
+		Set skillBuildOrder in the array form: [[skill, count, satisfy], [skill, count, satisfy], ... [skill, count, satisfy]]
+		 skill - skill id number (see /sdk/skills.txt)
+		 count - maximum number of skill points to allocate for that skill
+		 satisfy - boolean value to stop(true) or continue(false) further allocation until count is met. Defaults to true if not specified.
+
+		skillBuildOrder = [
+			[37, 1, true], [42, 1, true], [54, 1, true],  //warmth, static, teleport
+			[59, 1, false], [55, 7, true], [45, 13, true], //blizzard, glacial spike, ice blast
+			[59, 7, false], [65, 1, true], //blizzard, cold mastery
+			[59, 20, false], [65, 20, true], //max blizzard, max cold mastery
+			[55, 20, true], [45, 20, true], //max glacial spike, max ice blast
+		];
+	*/
+
+	this.needPreReq = function (skillid) {	//a function to return false if have all prereqs or a skill if not
+		for (var t = 183; t >=181; t--) {		//a loop to go through each reqskill
+			var preReq = (getBaseStat('skills', skillid, t));      // Check ReqSkills
+
+			if (preReq > 0 && preReq < 356 && !me.getSkill(preReq, 0)) {
+				return preReq;
+			}
+		}
+
+		return false;
+	};
+
+	this.skillCheck = function (skillid, count){
+		if (me.getSkill(skillid, 0) <= me.charlvl - getBaseStat("skills", skillid, 176) && me.getSkill(skillid, 0) < count) {
+			return true;
+		}
+
+		return false;
+	};
+
+	this.skillToAdd = function (inputArray) {
+		for (var i = 0; i < inputArray.length; i += 1) {
+			// limit maximum allocation count to 20
+			if (inputArray[i][1] > 20) {
+				print("AutoSkill: Skill build index " + i + " has allocation count of " + inputArray[i][1] + " and it will be limited to 20");
+				inputArray[i][1] = 20;
+			}
+
+			// set satify condition as default if not specified
+			if (inputArray[i][2] === undefined)
+				inputArray[i][2] = true;
+
+			// check to see if skill count in previous array is satisfied
+			if (i > 0 && inputArray[i-1][2] && (!me.getSkill(inputArray[i-1][0], 0) ? 0 : me.getSkill(inputArray[i-1][0], 0)) < inputArray[i-1][1]) {
+				return false;
+			}
+
+			if (me.getSkill(inputArray[i][0], 0) && this.skillCheck(inputArray[i][0], inputArray[i][1])) {
+				return inputArray[i][0];
+			}
+
+			var reqIn,
+				reqOut = this.needPreReq(inputArray[i][0]);
+
+			if (!reqOut && this.skillCheck(inputArray[i][0], inputArray[i][1])) {
+				return inputArray[i][0];
+			}
+
+			while (reqOut) {
+				reqIn = reqOut;
+				reqOut = this.needPreReq(reqIn);
+			}
+
+			if (this.skillCheck(reqIn, 1)) {
+				return reqIn;
+			}
+		}
+
+		return false;
+	};
+
+	this.allocate = function () {
+		var tick = getTickCount();
+
+		this.remaining = me.getStat(5);
+
+		if (!getUIFlag(0x17)) {
+			var addTo = this.skillToAdd(this.skillBuildOrder);
+
+			if (addTo) {
+				print("AutoSkill: Using skill point in Skill ID: " + addTo);
+				delay(100);
+				useSkillPoint(addTo, 1);
+			}
+		}
+
+		while (getTickCount() - tick < 1500 + 2 * me.ping) {
+			if (this.remaining > me.getStat(5)) {
+				return true;
+			}
+
+			delay(100);
+		}
+
+		return false;
+	};
+
+	this.remaining = 0;
+	this.count = 0;
+
+	this.init = function (skillBuildOrder, save = 0) {
+		this.skillBuildOrder = skillBuildOrder;
+		this.save = save;
+
+		if (!this.skillBuildOrder || !this.skillBuildOrder.length) {
+			print("AutoSkill: No build array specified");
+
+			return false;
+		}
+
+		while (me.getStat(5) > this.save) {
+			this.allocate();
+			delay(200 + me.ping); // may need longer delay under high ping
+
+			// break out of loop if we have skill points available but cannot allocate further due to unsatisfied skill
+			if (me.getStat(5) === this.remaining) {
+				this.count += 1;
+			}
+
+			if (this.count > 2) {
+				break;
+			}
+		}
+
+		print("AutoSkill: Finished allocating skill points");
+
+		return true;
+	};
+
+	return true;
+};

--- a/d2bs/kolbot/libs/common/AutoStat.js
+++ b/d2bs/kolbot/libs/common/AutoStat.js
@@ -1,0 +1,744 @@
+/**
+*	@filename	AutoStat.js
+*	@author		IMBA
+*	@desc		Automatically allocate stat points
+*/
+
+var AutoStat = new function () {
+	this.statBuildOrder = [];
+	this.save = 0;
+	this.block = 0;
+	this.bulkStat = true;
+
+	/*	statBuildOrder - array of stat points to spend in order
+		save - remaining stat points that will not be spent and saved.
+		block - an integer value set to desired block chance. This is ignored in classic.
+		bulkStat - set true to spend multiple stat points at once (up to 100), or false to spend 1 point at a time.
+
+		statBuildOrder Settings
+		The script will stat in the order of precedence. You may want to stat strength or dexterity first.
+
+		Set stats to desired integer value, and it will stat *hard points up to the desired value.
+		You can also set to string value "all", and it will spend all the remaining points.
+		Dexterity can be set to "block" and it will stat dexterity up the the desired block value specified in arguemnt (ignored in classic).
+
+		statBuildOrder = [
+			["strength", 25], ["energy", 75], ["vitality", 75],
+			["strength", 55], ["vitality", "all"]
+		];
+	*/
+
+	this.getBlock = function () {
+		var shield = false,
+			item = me.getItem(-1, 1);
+
+		// make sure character has shield equipped
+		if (item) {
+			do {
+				if ([4, 5].indexOf(item.bodylocation) > -1 && [2, 51, 69, 70].indexOf(item.itemType) > -1) {
+					shield = true;
+				}
+			} while (item.getNext());
+		}
+
+		if (!shield) {
+			return this.block;
+		}
+
+		// cast holy shield if available
+		if (me.getSkill(117, 0) && !me.getState(101)) {
+			if (Precast.precastSkill(117)) {
+				delay(1000);
+			} else {
+				return this.block;
+			}
+		}
+
+		if (me.gametype === 0) { // classic
+			return Math.floor(me.getStat(20) + getBaseStat(15, me.classid, 23));
+		}
+
+		return Math.min(75, Math.floor((me.getStat(20) + getBaseStat(15, me.classid, 23)) * (me.getStat(2) - 15) / (me.charlvl * 2)));
+	};
+
+	// this check may not be necessary with this.validItem(), but consider it double check
+	this.verifySetStats = function (unit, type, stats) { //verify that the set bonuses are there
+		var i, temp, string;
+
+		if (type === 0) {
+			string = 3473 //to strength
+		} else {
+			string = 3474 //to dexterity
+		}
+
+		if (unit) {
+			temp = unit.description.split("\n");
+
+			for (i = 0; i < temp.length; i += 1) {
+				if (temp[i].match(getLocaleString(string), "i")) {
+					if (parseInt(temp[i].replace(/(y|ÿ)c[0-9!"+<;.*]/, ""), 10) === stats) {
+						return true;
+					}
+				}
+			}
+		}
+
+		return false;
+	};
+
+	this.validItem = function (item) {
+		// ignore item bonuses from secondary weapon slot
+		if (me.gametype === 1 && [11, 12].indexOf(item.bodylocation) > -1) {
+			return false;
+		}
+
+		// check if character meets str, dex, and level requirement since stat bonuses only apply when they are active
+		return me.getStat(0) >= item.strreq && me.getStat(2) >= item.dexreq && me.charlvl >= item.lvlreq;
+	};
+
+	this.setBonus = function (type) { //get stats from set bonuses
+		if (type === 1 || type === 3) { //set bonuses do not have energy or vitality (we can ignore this)
+			return 0;
+		}
+
+		var sets = { //these are the only sets with possible stat bonuses
+			"angelic": [], "artic": [], "civerb": [], "iratha": [],
+			"isenhart": [], "vidala": [], "cowking": [], "disciple": [],
+			"griswold": [], "mavina": [], "naj": [], "orphan": []
+		};
+
+		var i, j, setStat = 0,
+			items = me.getItems();
+
+		if (items) {
+			for (i = 0; i < items.length; i += 1) {
+				if (items[i].mode === 1 && items[i].quality === 5 && this.validItem(items[i])) {
+idSwitch:
+					switch (items[i].classid) {
+					case 311: //crown
+						if (items[i].getStat(41) === 30) { //light resist
+							sets.iratha.push(items[i]);
+						}
+
+						break;
+					case 337: //light gauntlet
+						if (items[i].getStat(7) === 20) { //life
+							sets.artic.push(items[i]);
+						} else if (items[i].getStat(43) === 30) { //cold resist
+							sets.iratha.push(items[i]);
+						}
+
+						break;
+					case 340: //heavy boots
+						if (items[i].getStat(2) === 20) { //dexterity
+							sets.cowking.push(items[i]);
+						}
+
+						break;
+					case 347: //heavy belt
+						if (items[i].getStat(21) === 5) { //min damage
+							sets.iratha.push(items[i]);
+						}
+
+						break;
+					case 520: //amulet
+						if (items[i].getStat(114) === 20) { //damage to mana
+							sets.angelic.push(items[i]);
+						} else if (items[i].getStat(74) === 4) { //replenish life
+							sets.civerb.push(items[i]);
+						} else if (items[i].getStat(110) === 75) { //poison length reduced
+							sets.iratha.push(items[i]);
+						} else if (items[i].getStat(43) === 20) { //cold resist
+							sets.vidala.push(items[i]);
+						} else if (items[i].getStat(43) === 18) { //cold resist
+							sets.disciple.push(items[i]);
+						}
+
+						break;
+					case 522: //ring
+						if (items[i].getStat(74) === 6) { //replenish life
+							for (j = 0; j < sets.angelic.length; j += 1) { //do not count ring twice
+								if (sets.angelic[j].classid === items[i].classid) {
+									break idSwitch;
+								}
+							}
+
+							sets.angelic.push(items[i]);
+						}
+
+						break;
+					case 27: //sabre
+						for (j = 0; j < sets.angelic.length; j += 1) { //do not count twice in case of dual wield
+							if (sets.angelic[j].classid === items[i].classid) {
+								break idSwitch;
+							}
+						}
+
+						sets.angelic.push(items[i]);
+
+						break;
+					case 317: //ring mail
+						sets.angelic.push(items[i]);
+
+						break;
+					case 74: //short war bow
+					case 313: //quilted armor
+					case 345: //light belt
+						sets.artic.push(items[i]);
+
+						break;
+					case 16: //grand scepter
+						for (j = 0; j < sets.civerb.length; j += 1) { //do not count twice in case of dual wield
+							if (sets.civerb[j].classid === items[i].classid) {
+								break idSwitch;
+							}
+						}
+
+						sets.civerb.push(items[i]);
+
+						break;
+					case 330:
+						sets.civerb.push(items[i]);
+
+						break;
+					case 30: //broad sword
+						for (j = 0; j < sets.isenhart.length; j += 1) { //do not count twice in case of dual wield
+							if (sets.isenhart[j].classid === items[i].classid) {
+								break idSwitch;
+							}
+						}
+
+						sets.isenhart.push(items[i]);
+
+						break;
+					case 309: //full helm
+					case 320: //breast plate
+					case 333: //gothic shield
+						sets.isenhart.push(items[i]);
+
+						break;
+					case 73: //long battle bow
+					case 314: //leather armor
+					case 342: //light plated boots
+						sets.vidala.push(items[i]);
+
+						break;
+					case 316: //studded leather
+					case 352: //war hat
+						sets.cowking.push(items[i]);
+
+						break;
+					case 385: //demonhide boots
+					case 429: //dusk shroud
+					case 450: //bramble mitts
+					case 462: //mithril coil
+						sets.disciple.push(items[i]);
+
+						break;
+					case 213: //caduceus
+						for (j = 0; j < sets.griswold.length; j += 1) { //do not count twice in case of dual wield
+							if (sets.griswold[j].classid === items[i].classid) {
+								break idSwitch;
+							}
+						}
+
+						sets.griswold.push(items[i]);
+
+						break;
+					case 372: //ornate plate
+					case 427: //corona
+					case 502: //vortex shield
+						sets.griswold.push(items[i]);
+
+						break;
+					case 302: //grand matron bow
+					case 383: //battle gauntlets
+					case 391: //sharkskin belt
+					case 421: //diadem
+					case 439: //kraken shell
+						sets.mavina.push(items[i]);
+
+						break;
+					case 261: //elder staff
+					case 418: //circlet
+					case 438: //hellforge plate
+						sets.naj.push(items[i]);
+
+						break;
+					case 356: //winged helm
+					case 375: //round shield
+					case 381: //sharkskin gloves
+					case 393: //battle belt
+						sets.orphan.push(items[i]);
+
+						break;
+					}
+				}
+			}
+		}
+
+		for (i in sets) {
+			if (sets.hasOwnProperty(i)) {
+MainSwitch:
+				switch (i) {
+				case "angelic":
+					if (sets[i].length >= 2 && type === 2) {
+						for (j = 0; j < sets[i].length; j += 1) {
+							if (!this.verifySetStats(sets[i][j], type, 10)) {
+								break MainSwitch;
+							}
+						}
+
+						setStat += 10;
+					}
+
+					break;
+				case "artic":
+					if (sets[i].length >= 2 && type === 0) {
+						for (j = 0; j < sets[i].length; j += 1) {
+							if (!this.verifySetStats(sets[i][j], type, 5)) {
+								break MainSwitch;
+							}
+						}
+
+						setStat += 5;
+					}
+
+					break;
+				case "civerb":
+					if (sets[i].length === 3 && type === 0) {
+						for (j = 0; j < sets[i].length; j += 1) {
+							if (!this.verifySetStats(sets[i][j], type, 15)) {
+								break MainSwitch;
+							}
+						}
+
+						setStat += 15;
+					}
+
+					break;
+				case "iratha":
+					if (sets[i].length === 4 && type === 2) {
+						for (j = 0; j < sets[i].length; j += 1) {
+							if (!this.verifySetStats(sets[i][j], type, 15)) {
+								break MainSwitch;
+							}
+						}
+
+						setStat += 15;
+					}
+
+					break;
+				case "isenhart":
+					if (sets[i].length >= 2 && type === 0) {
+						for (j = 0; j < sets[i].length; j += 1) {
+							if (!this.verifySetStats(sets[i][j], type, 10)) {
+								break MainSwitch;
+							}
+						}
+
+						setStat += 10;
+					}
+
+					if (sets[i].length >= 3 && type === 2) {
+						for (j = 0; j < sets[i].length; j += 1) {
+							if (!this.verifySetStats(sets[i][j], type, 10)) {
+								break MainSwitch;
+							}
+						}
+
+						setStat += 10;
+					}
+
+					break;
+				case "vidala":
+					if (sets[i].length >= 3 && type === 2) {
+						for (j = 0; j < sets[i].length; j += 1) {
+							if (!this.verifySetStats(sets[i][j], type, 15)) {
+								break MainSwitch;
+							}
+						}
+
+						setStat += 15;
+					}
+
+					if (sets[i].length === 4 && type === 0) {
+						for (j = 0; j < sets[i].length; j += 1) {
+							if (!this.verifySetStats(sets[i][j], type, 10)) {
+								break MainSwitch;
+							}
+						}
+
+						setStat += 10;
+					}
+
+					break;
+				case "cowking":
+					if (sets[i].length === 3 && type === 0) {
+						for (j = 0; j < sets[i].length; j += 1) {
+							if (!this.verifySetStats(sets[i][j], type, 20)) {
+								break MainSwitch;
+							}
+						}
+
+						setStat += 20;
+					}
+
+					break;
+				case "disciple":
+					if (sets[i].length >= 4 && type === 0) {
+						for (j = 0; j < sets[i].length; j += 1) {
+							if (!this.verifySetStats(sets[i][j], type, 10)) {
+								break MainSwitch;
+							}
+						}
+
+						setStat += 10;
+					}
+
+					break;
+				case "griswold":
+					if (sets[i].length >= 2 && type === 0) {
+						for (j = 0; j < sets[i].length; j += 1) {
+							if (!this.verifySetStats(sets[i][j], type, 20)) {
+								break MainSwitch;
+							}
+						}
+
+						setStat += 20;
+					}
+
+					if (sets[i].length >= 3 && type === 2) {
+						for (j = 0; j < sets[i].length; j += 1) {
+							if (!this.verifySetStats(sets[i][j], type, 30)) {
+								break MainSwitch;
+							}
+						}
+
+						setStat += 30;
+					}
+
+					break;
+				case "mavina":
+					if (sets[i].length >= 2 && type === 0) {
+						for (j = 0; j < sets[i].length; j += 1) {
+							if (!this.verifySetStats(sets[i][j], type, 20)) {
+								break MainSwitch;
+							}
+						}
+
+						setStat += 20;
+					}
+
+					if (sets[i].length >= 3 && type === 2) {
+						for (j = 0; j < sets[i].length; j += 1) {
+							if (!this.verifySetStats(sets[i][j], type, 30)) {
+								break MainSwitch;
+							}
+						}
+
+						setStat += 30;
+					}
+
+					break;
+				case "naj":
+					if (sets[i].length === 3 && type === 2) {
+						for (j = 0; j < sets[i].length; j += 1) {
+							if (!this.verifySetStats(sets[i][j], type, 15)) {
+								break MainSwitch;
+							}
+						}
+
+						setStat += 15;
+					}
+
+					if (sets[i].length === 3 && type === 0) {
+						for (j = 0; j < sets[i].length; j += 1) {
+							if (!this.verifySetStats(sets[i][j], type, 20)) {
+								break MainSwitch;
+							}
+						}
+
+						setStat += 20;
+					}
+
+					break;
+				case "orphan":
+					if (sets[i].length === 4 && type === 2) {
+						for (j = 0; j < sets[i].length; j += 1) {
+							if (!this.verifySetStats(sets[i][j], type, 10)) {
+								break MainSwitch;
+							}
+						}
+
+						setStat += 10;
+					}
+
+					if (sets[i].length === 4 && type === 0) {
+						for (j = 0; j < sets[i].length; j += 1) {
+							if (!this.verifySetStats(sets[i][j], type, 20)) {
+								break MainSwitch;
+							}
+						}
+
+						setStat += 20;
+					}
+
+					break;
+				}
+			}
+		}
+
+		return setStat;
+	};
+
+	this.getHardStats = function (type) { // return stat values excluding stat bonuses from sets and/or items
+		var i, statID,
+			addedStat = 0,
+			items = me.getItems();
+
+		switch (type) {
+		case 0: // strength
+			type = 0;
+			statID = 220;
+
+			break;
+		case 1: // energy
+			type = 1;
+			statID = 222;
+
+			break;
+		case 2: // dexterity
+			type = 2;
+			statID = 221;
+
+			break;
+		case 3: // vitality
+			type = 3;
+			statID = 223;
+
+			break;
+		}
+
+		if (items) {
+			for (i = 0; i < items.length; i += 1) {
+				// items equipped or charms in inventory
+				if ((items[i].mode === 1 || (items[i].location === 3 && [82, 83, 84].indexOf(items[i].itemType) > -1)) && this.validItem(items[i])) {
+					// stats
+					if (items[i].getStat(type)) {
+						addedStat += items[i].getStat(type);
+					}
+
+					// stats per level
+					if (items[i].getStat(statID)) {
+						addedStat += Math.floor(items[i].getStat(statID) / 8 * me.charlvl);
+					}
+				}
+			}
+		}
+
+		return (me.getStat(type) - addedStat - this.setBonus(type));
+	};
+
+	this.requiredDex = function () {
+		var i, set = false,
+			inactiveDex = 0,
+			items = me.getItems();
+
+		if (items) {
+			for (i = 0; i < items.length; i += 1) {
+				// items equipped but inactive (these are possible dex sources unseen by me.getStat(2))
+				if (items[i].mode === 1 && [11, 12].indexOf(items[i].bodylocation) === -1 && !this.validItem(items[i])) {
+					if (items[i].quality === 5) {
+						set = true;
+
+						break;
+					}
+
+					// stats
+					if (items[i].getStat(2)) {
+						inactiveDex += items[i].getStat(2);
+					}
+
+					// stats per level
+					if (items[i].getStat(221)) {
+						inactiveDex += Math.floor(items[i].getStat(221) / 8 * me.charlvl);
+					}
+				}
+			}
+		}
+
+		// just stat 1 at a time if there's set item (there could be dex bonus for currently inactive set)
+		if (set) {
+			return 1;
+		}
+
+		// returns amount of dexterity required to get the desired block chance
+		return Math.ceil((2 * me.charlvl * this.block) / (me.getStat(20) + getBaseStat(15, me.classid, 23)) + 15) - me.getStat(2) - inactiveDex;
+	};
+
+	this.useStats = function (type, goal = false) {
+		var currStat = me.getStat(4),
+			tick = getTickCount(),
+			statIDToString = [getLocaleString(4060), getLocaleString(4069), getLocaleString(4062), getLocaleString(4066)];
+
+		// use 0x3a packet to spend multiple stat points at once (up to 100)
+		if (this.bulkStat) {
+			if (goal) {
+				sendPacket(1, 0x3a, 1, type, 1, Math.min(me.getStat(4) - this.save - 1, goal - 1, 99));
+			} else {
+				sendPacket(1, 0x3a, 1, type, 1, Math.min(me.getStat(4) - this.save - 1, 99));
+			}
+		} else {
+			useStatPoint(type);
+		}
+
+		while (getTickCount() - tick < 3000) {
+			if (currStat > me.getStat(4)) {
+				print("AutoStat: Using " + (currStat - me.getStat(4)) + " stat points in " + statIDToString[type]);
+				return true;
+			}
+
+			delay(100);
+		}
+
+		return false;
+	};
+
+	this.addStatPoint = function () {
+		var i, hardStats;
+
+		this.remaining = me.getStat(4);
+
+		for (i = 0; i < this.statBuildOrder.length; i += 1) {
+			switch (this.statBuildOrder[i][0]) {
+			case 0:
+			case "s":
+			case "str":
+			case "strength":
+				if (typeof this.statBuildOrder[i][1] === "string") {
+					switch (this.statBuildOrder[i][1]) {
+					case "all":
+						return this.useStats(0);
+					default:
+						break;
+					}
+				} else {
+					hardStats = this.getHardStats(0);
+
+					if (hardStats < this.statBuildOrder[i][1]) {
+						return this.useStats(0, this.statBuildOrder[i][1] - hardStats);
+					}
+				}
+
+				break;
+			case 1:
+			case "e":
+			case "enr":
+			case "energy":
+				if (typeof this.statBuildOrder[i][1] === "string") {
+					switch (this.statBuildOrder[i][1]) {
+					case "all":
+						return this.useStats(1);
+					default:
+						break;
+					}
+				} else {
+					hardStats = this.getHardStats(1);
+
+					if (hardStats < this.statBuildOrder[i][1]) {
+						return this.useStats(1, this.statBuildOrder[i][1] - hardStats);
+					}
+				}
+
+				break;
+			case 2:
+			case "d":
+			case "dex":
+			case "dexterity":
+				if (typeof this.statBuildOrder[i][1] === "string") {
+					switch (this.statBuildOrder[i][1]) {
+					case "block":
+						if (me.gametype === 1) {
+							if (this.getBlock() < this.block) {
+								return this.useStats(2, this.requiredDex());
+							}
+						}
+
+						break;
+					case "all":
+						return this.useStats(2);
+					default:
+						break;
+					}
+				} else {
+					hardStats = this.getHardStats(2);
+
+					if (hardStats < this.statBuildOrder[i][1]) {
+						return this.useStats(2, this.statBuildOrder[i][1] - hardStats);
+					}
+				}
+
+				break;
+			case 3:
+			case "v":
+			case "vit":
+			case "vitality":
+				if (typeof this.statBuildOrder[i][1] === "string") {
+					switch (this.statBuildOrder[i][1]) {
+					case "all":
+						return this.useStats(3);
+					default:
+						break;
+					}
+				} else {
+					hardStats = this.getHardStats(3);
+
+					if (hardStats < this.statBuildOrder[i][1]) {
+						return this.useStats(3, this.statBuildOrder[i][1] - hardStats);
+					}
+				}
+
+				break;
+			}
+		}
+
+		return false;
+	};
+
+	this.remaining = 0;
+	this.count = 0;
+
+	this.init = function (statBuildOrder, save = 0, block = 0, bulkStat = true) {
+		this.statBuildOrder = statBuildOrder;
+		this.save = save;
+		this.block = block;
+		this.bulkStat = bulkStat;
+
+		if (!this.statBuildOrder || !this.statBuildOrder.length) {
+			print("AutoStat: No build array specified");
+
+			return false;
+		}
+
+		while (me.getStat(4) > this.save) {
+			this.addStatPoint();
+			delay(150 + me.ping); // spending multiple single stat at a time with short delay may cause r/d
+
+			// break out of loop if we have stat points available but finished allocating as configured
+			if (me.getStat(4) === this.remaining) {
+				this.count += 1;
+			}
+
+			if (this.count > 2) {
+				break;
+			}
+		}
+
+		print("AutoStat: Finished allocating stat points");
+
+		return true;
+	};
+
+	return true;
+};

--- a/d2bs/kolbot/libs/common/Config.js
+++ b/d2bs/kolbot/libs/common/Config.js
@@ -504,6 +504,18 @@ var Config = {
 		Quester: false,
 		Bumper: false
 	},
+	AutoSkill: {
+		Enabled: false,
+		Build: [],
+		Save: 0
+	},
+	AutoStat: {
+		Enabled: false,
+		Build: [],
+		Save: 0,
+		BlockChance: 0,
+		UseBulk: true
+	},
 	AutoBuild: {
 		Enabled: false,
 		Template: "",

--- a/d2bs/kolbot/libs/config/Amazon.js
+++ b/d2bs/kolbot/libs/config/Amazon.js
@@ -512,32 +512,31 @@ function LoadConfig() {
 	Config.LightningFuryDelay = 10; // Lightning fury interval in seconds. LF is treated as timed skill.
 	Config.SummonValkyrie = true; // Summon Valkyrie
 
-	/*	AutoStat and AutoSkill system builds character based on array defined by the user.
-		When enabled, this system will replace AutoBuild's skill/stat system respectively. So please make sure to configure Build array.
-
-		***AutoSkill will automatically spend skill points and it can also allocate any prerequisite skills as required.
-
-		Format: Config.AutoSkill.Build = [[skillID, count, satisfy], [skillID, count, satisfy], ... [skillID, count, satisfy]];
-		 skill - skill id number (see /sdk/skills.txt)
-		 count - maximum number of skill points to allocate for that skill
-		 satisfy - boolean value to stop(true) or continue(false) further allocation until count is met. Defaults to true if not specified.
-
-		 See Templates/AutoSkillExampleBuilds.txt for Config.AutoSkill.Build examples.
-
-		***AutoStat will stat in the order of precedence. You may want to stat strength or dexterity first to meet item requirements.
-
-		Format: Config.AutoStat.Build = [[statType, stat], [statType, stat], ... [statType, stat]];
-		 statType - defined as string, or as corresponding stat integer. "strength" or 0, "dexterity" or 2, "vitality" or 3, "energy" or 1
-		 stat - set to an integer value, and it will spend stat points until it reaches desired *hard stat value (*+stats from items are ignored).
-		 You can also set stat to string value "all", and it will spend all the remaining points.
-		 Dexterity can be set to "block" and it will stat dexterity up the the desired block value specified in arguemnt (ignored in classic).
-
-		 See Templates/AutoStatExampleBuilds.txt for Config.AutoStat.Build examples. 
-	*/
+	/* AutoSkill builds character based on array defined by the user and it replaces AutoBuild's skill system.
+	 * AutoSkill will automatically spend skill points and it can also allocate any prerequisite skills as required.
+     *
+	 * Format: Config.AutoSkill.Build = [[skillID, count, satisfy], [skillID, count, satisfy], ... [skillID, count, satisfy]];
+	 *	skill - skill id number (see /sdk/skills.txt)
+	 *	count - maximum number of skill points to allocate for that skill
+	 *	satisfy - boolean value to stop(true) or continue(false) further allocation until count is met. Defaults to true if not specified.
+     *
+	 *	See libs/config/Templates/AutoSkillExampleBuilds.txt for Config.AutoSkill.Build examples.
+	 */
 	Config.AutoSkill.Enabled = false; // Enable or disable AutoSkill system
 	Config.AutoSkill.Save = 0; // Number of skill points that will not be spent and saved
 	Config.AutoSkill.Build = [];
 
+	/* AutoStat builds character based on array defined by the user and this will replace AutoBuild's stat system.
+	 * AutoStat will stat Build array order. You may want to stat strength or dexterity first to meet item requirements.
+     *
+	 * Format: Config.AutoStat.Build = [[statType, stat], [statType, stat], ... [statType, stat]];
+	 *	statType - defined as string, or as corresponding stat integer. "strength" or 0, "dexterity" or 2, "vitality" or 3, "energy" or 1
+	 *	stat - set to an integer value, and it will spend stat points until it reaches desired *hard stat value (*+stats from items are ignored).
+	 *	You can also set stat to string value "all", and it will spend all the remaining points.
+	 *	Dexterity can be set to "block" and it will stat dexterity up the the desired block value specified in arguemnt (ignored in classic).
+     *
+	 *	See libs/config/Templates/AutoStatExampleBuilds.txt for Config.AutoStat.Build examples. 
+	 */
 	Config.AutoStat.Enabled = false; // Enable or disable AutoStat system
 	Config.AutoStat.Save = 0; // Number stat points that will not be spent and saved.
 	Config.AutoStat.BlockChance = 0; // An integer value set to desired block chance. This is ignored in classic.

--- a/d2bs/kolbot/libs/config/Amazon.js
+++ b/d2bs/kolbot/libs/config/Amazon.js
@@ -514,12 +514,12 @@ function LoadConfig() {
 
 	/* AutoSkill builds character based on array defined by the user and it replaces AutoBuild's skill system.
 	 * AutoSkill will automatically spend skill points and it can also allocate any prerequisite skills as required.
-     *
+	 *
 	 * Format: Config.AutoSkill.Build = [[skillID, count, satisfy], [skillID, count, satisfy], ... [skillID, count, satisfy]];
 	 *	skill - skill id number (see /sdk/skills.txt)
 	 *	count - maximum number of skill points to allocate for that skill
 	 *	satisfy - boolean value to stop(true) or continue(false) further allocation until count is met. Defaults to true if not specified.
-     *
+	 *
 	 *	See libs/config/Templates/AutoSkillExampleBuilds.txt for Config.AutoSkill.Build examples.
 	 */
 	Config.AutoSkill.Enabled = false; // Enable or disable AutoSkill system
@@ -528,13 +528,13 @@ function LoadConfig() {
 
 	/* AutoStat builds character based on array defined by the user and this will replace AutoBuild's stat system.
 	 * AutoStat will stat Build array order. You may want to stat strength or dexterity first to meet item requirements.
-     *
+	 *
 	 * Format: Config.AutoStat.Build = [[statType, stat], [statType, stat], ... [statType, stat]];
 	 *	statType - defined as string, or as corresponding stat integer. "strength" or 0, "dexterity" or 2, "vitality" or 3, "energy" or 1
 	 *	stat - set to an integer value, and it will spend stat points until it reaches desired *hard stat value (*+stats from items are ignored).
 	 *	You can also set stat to string value "all", and it will spend all the remaining points.
 	 *	Dexterity can be set to "block" and it will stat dexterity up the the desired block value specified in arguemnt (ignored in classic).
-     *
+	 *
 	 *	See libs/config/Templates/AutoStatExampleBuilds.txt for Config.AutoStat.Build examples. 
 	 */
 	Config.AutoStat.Enabled = false; // Enable or disable AutoStat system

--- a/d2bs/kolbot/libs/config/Amazon.js
+++ b/d2bs/kolbot/libs/config/Amazon.js
@@ -512,6 +512,37 @@ function LoadConfig() {
 	Config.LightningFuryDelay = 10; // Lightning fury interval in seconds. LF is treated as timed skill.
 	Config.SummonValkyrie = true; // Summon Valkyrie
 
+	/*	AutoStat and AutoSkill system builds character based on array defined by the user.
+		When enabled, this system will replace AutoBuild's skill/stat system respectively. So please make sure to configure Build array.
+
+		***AutoSkill will automatically spend skill points and it can also allocate any prerequisite skills as required.
+
+		Format: Config.AutoSkill.Build = [[skillID, count, satisfy], [skillID, count, satisfy], ... [skillID, count, satisfy]];
+		 skill - skill id number (see /sdk/skills.txt)
+		 count - maximum number of skill points to allocate for that skill
+		 satisfy - boolean value to stop(true) or continue(false) further allocation until count is met. Defaults to true if not specified.
+
+		 See Templates/AutoSkillExampleBuilds.txt for Config.AutoSkill.Build examples.
+
+		***AutoStat will stat in the order of precedence. You may want to stat strength or dexterity first to meet item requirements.
+
+		Format: Config.AutoStat.Build = [[statType, stat], [statType, stat], ... [statType, stat]];
+		 statType - defined as string, or as corresponding stat integer. "strength" or 0, "dexterity" or 2, "vitality" or 3, "energy" or 1
+		 stat - set to an integer value, and it will spend stat points until it reaches desired *hard stat value (*+stats from items are ignored).
+		 You can also set stat to string value "all", and it will spend all the remaining points.
+		 Dexterity can be set to "block" and it will stat dexterity up the the desired block value specified in arguemnt (ignored in classic).
+
+		 See Templates/AutoStatExampleBuilds.txt for Config.AutoStat.Build examples. 
+	*/
+	Config.AutoSkill.Enabled = false; // Enable or disable AutoSkill system
+	Config.AutoSkill.Save = 0; // Number of skill points that will not be spent and saved
+	Config.AutoSkill.Build = [];
+
+	Config.AutoStat.Enabled = false; // Enable or disable AutoStat system
+	Config.AutoStat.Save = 0; // Number stat points that will not be spent and saved.
+	Config.AutoStat.BlockChance = 0; // An integer value set to desired block chance. This is ignored in classic.
+	Config.AutoStat.UseBulk = true; // Set true to spend multiple stat points at once (up to 100), or false to spend singe point at a time.
+	Config.AutoStat.Build = [];
 
 	// AutoBuild System ( See /d2bs/kolbot/libs/config/Builds/README.txt for instructions )
 	Config.AutoBuild.Enabled = false;			//	This will enable or disable the AutoBuild system

--- a/d2bs/kolbot/libs/config/Assassin.js
+++ b/d2bs/kolbot/libs/config/Assassin.js
@@ -520,32 +520,31 @@ function LoadConfig() {
 	Config.UseCloakofShadows = true; // Set to true to use Cloak of Shadows while fighting. Useful for blinding regular monsters/minions.
 	Config.AggressiveCloak = false; // Move into Cloak range or cast if already close
 
-	/*	AutoStat and AutoSkill system builds character based on array defined by the user
-		When enabled, this system will replace AutoBuild's skill/stat system respectively. So please make sure to configure Build array.
-
-		***AutoSkill will automatically spend skill points and it can also allocate any prerequisite skills as required.
-
-		Format: Config.AutoSkill.Build = [[skillID, count, satisfy], [skillID, count, satisfy], ... [skillID, count, satisfy]];
-		 skill - skill id number (see /sdk/skills.txt)
-		 count - maximum number of skill points to allocate for that skill
-		 satisfy - boolean value to stop(true) or continue(false) further allocation until count is met. Defaults to true if not specified.
-
-		 See Templates/AutoSkillExampleBuilds.txt for Config.AutoSkill.Build examples.
-
-		***AutoStat will stat in the order of precedence. You may want to stat strength or dexterity first to meet item requirements.
-
-		Format: Config.AutoStat.Build = [[statType, stat], [statType, stat], ... [statType, stat]];
-		 statType - defined as string, or as corresponding stat integer. "strength" or 0, "dexterity" or 2, "vitality" or 3, "energy" or 1
-		 stat - set to an integer value, and it will spend stat points until it reaches desired *hard stat value (*+stats from items are ignored).
-		 You can also set stat to string value "all", and it will spend all the remaining points.
-		 Dexterity can be set to "block" and it will stat dexterity up the the desired block value specified in arguemnt (ignored in classic).
-
-		 See Templates/AutoStatExampleBuilds.txt for Config.AutoStat.Build examples. 
-	*/
+	/* AutoSkill builds character based on array defined by the user and it replaces AutoBuild's skill system.
+	 * AutoSkill will automatically spend skill points and it can also allocate any prerequisite skills as required.
+     *
+	 * Format: Config.AutoSkill.Build = [[skillID, count, satisfy], [skillID, count, satisfy], ... [skillID, count, satisfy]];
+	 *	skill - skill id number (see /sdk/skills.txt)
+	 *	count - maximum number of skill points to allocate for that skill
+	 *	satisfy - boolean value to stop(true) or continue(false) further allocation until count is met. Defaults to true if not specified.
+     *
+	 *	See libs/config/Templates/AutoSkillExampleBuilds.txt for Config.AutoSkill.Build examples.
+	 */
 	Config.AutoSkill.Enabled = false; // Enable or disable AutoSkill system
 	Config.AutoSkill.Save = 0; // Number of skill points that will not be spent and saved
 	Config.AutoSkill.Build = [];
 
+	/* AutoStat builds character based on array defined by the user and this will replace AutoBuild's stat system.
+	 * AutoStat will stat Build array order. You may want to stat strength or dexterity first to meet item requirements.
+     *
+	 * Format: Config.AutoStat.Build = [[statType, stat], [statType, stat], ... [statType, stat]];
+	 *	statType - defined as string, or as corresponding stat integer. "strength" or 0, "dexterity" or 2, "vitality" or 3, "energy" or 1
+	 *	stat - set to an integer value, and it will spend stat points until it reaches desired *hard stat value (*+stats from items are ignored).
+	 *	You can also set stat to string value "all", and it will spend all the remaining points.
+	 *	Dexterity can be set to "block" and it will stat dexterity up the the desired block value specified in arguemnt (ignored in classic).
+     *
+	 *	See libs/config/Templates/AutoStatExampleBuilds.txt for Config.AutoStat.Build examples. 
+	 */
 	Config.AutoStat.Enabled = false; // Enable or disable AutoStat system
 	Config.AutoStat.Save = 0; // Number stat points that will not be spent and saved.
 	Config.AutoStat.BlockChance = 0; // An integer value set to desired block chance. This is ignored in classic.

--- a/d2bs/kolbot/libs/config/Assassin.js
+++ b/d2bs/kolbot/libs/config/Assassin.js
@@ -520,6 +520,37 @@ function LoadConfig() {
 	Config.UseCloakofShadows = true; // Set to true to use Cloak of Shadows while fighting. Useful for blinding regular monsters/minions.
 	Config.AggressiveCloak = false; // Move into Cloak range or cast if already close
 
+	/*	AutoStat and AutoSkill system builds character based on array defined by the user
+		When enabled, this system will replace AutoBuild's skill/stat system respectively. So please make sure to configure Build array.
+
+		***AutoSkill will automatically spend skill points and it can also allocate any prerequisite skills as required.
+
+		Format: Config.AutoSkill.Build = [[skillID, count, satisfy], [skillID, count, satisfy], ... [skillID, count, satisfy]];
+		 skill - skill id number (see /sdk/skills.txt)
+		 count - maximum number of skill points to allocate for that skill
+		 satisfy - boolean value to stop(true) or continue(false) further allocation until count is met. Defaults to true if not specified.
+
+		 See Templates/AutoSkillExampleBuilds.txt for Config.AutoSkill.Build examples.
+
+		***AutoStat will stat in the order of precedence. You may want to stat strength or dexterity first to meet item requirements.
+
+		Format: Config.AutoStat.Build = [[statType, stat], [statType, stat], ... [statType, stat]];
+		 statType - defined as string, or as corresponding stat integer. "strength" or 0, "dexterity" or 2, "vitality" or 3, "energy" or 1
+		 stat - set to an integer value, and it will spend stat points until it reaches desired *hard stat value (*+stats from items are ignored).
+		 You can also set stat to string value "all", and it will spend all the remaining points.
+		 Dexterity can be set to "block" and it will stat dexterity up the the desired block value specified in arguemnt (ignored in classic).
+
+		 See Templates/AutoStatExampleBuilds.txt for Config.AutoStat.Build examples. 
+	*/
+	Config.AutoSkill.Enabled = false; // Enable or disable AutoSkill system
+	Config.AutoSkill.Save = 0; // Number of skill points that will not be spent and saved
+	Config.AutoSkill.Build = [];
+
+	Config.AutoStat.Enabled = false; // Enable or disable AutoStat system
+	Config.AutoStat.Save = 0; // Number stat points that will not be spent and saved.
+	Config.AutoStat.BlockChance = 0; // An integer value set to desired block chance. This is ignored in classic.
+	Config.AutoStat.UseBulk = true; // Set true to spend multiple stat points at once (up to 100), or false to spend singe point at a time.
+	Config.AutoStat.Build = [];
 
 	// AutoBuild System ( See /d2bs/kolbot/libs/config/Builds/README.txt for instructions )
 	Config.AutoBuild.Enabled = false;			//	This will enable or disable the AutoBuild system

--- a/d2bs/kolbot/libs/config/Assassin.js
+++ b/d2bs/kolbot/libs/config/Assassin.js
@@ -522,12 +522,12 @@ function LoadConfig() {
 
 	/* AutoSkill builds character based on array defined by the user and it replaces AutoBuild's skill system.
 	 * AutoSkill will automatically spend skill points and it can also allocate any prerequisite skills as required.
-     *
+	 *
 	 * Format: Config.AutoSkill.Build = [[skillID, count, satisfy], [skillID, count, satisfy], ... [skillID, count, satisfy]];
 	 *	skill - skill id number (see /sdk/skills.txt)
 	 *	count - maximum number of skill points to allocate for that skill
 	 *	satisfy - boolean value to stop(true) or continue(false) further allocation until count is met. Defaults to true if not specified.
-     *
+	 *
 	 *	See libs/config/Templates/AutoSkillExampleBuilds.txt for Config.AutoSkill.Build examples.
 	 */
 	Config.AutoSkill.Enabled = false; // Enable or disable AutoSkill system
@@ -536,13 +536,13 @@ function LoadConfig() {
 
 	/* AutoStat builds character based on array defined by the user and this will replace AutoBuild's stat system.
 	 * AutoStat will stat Build array order. You may want to stat strength or dexterity first to meet item requirements.
-     *
+	 *
 	 * Format: Config.AutoStat.Build = [[statType, stat], [statType, stat], ... [statType, stat]];
 	 *	statType - defined as string, or as corresponding stat integer. "strength" or 0, "dexterity" or 2, "vitality" or 3, "energy" or 1
 	 *	stat - set to an integer value, and it will spend stat points until it reaches desired *hard stat value (*+stats from items are ignored).
 	 *	You can also set stat to string value "all", and it will spend all the remaining points.
 	 *	Dexterity can be set to "block" and it will stat dexterity up the the desired block value specified in arguemnt (ignored in classic).
-     *
+	 *
 	 *	See libs/config/Templates/AutoStatExampleBuilds.txt for Config.AutoStat.Build examples. 
 	 */
 	Config.AutoStat.Enabled = false; // Enable or disable AutoStat system

--- a/d2bs/kolbot/libs/config/Barbarian.js
+++ b/d2bs/kolbot/libs/config/Barbarian.js
@@ -505,6 +505,37 @@ function LoadConfig() {
 	Config.FindItem = false; // Use Find Item skill on corpses after clearing.
 	Config.FindItemSwitch = 0; // Find Item weapon slot - 0 = slot I, 1 = slot II
 
+	/*	AutoStat and AutoSkill system builds character based on array defined by the user
+		When enabled, this system will replace AutoBuild's skill/stat system respectively. So please make sure to configure Build array.
+
+		***AutoSkill will automatically spend skill points and it can also allocate any prerequisite skills as required.
+
+		Format: Config.AutoSkill.Build = [[skillID, count, satisfy], [skillID, count, satisfy], ... [skillID, count, satisfy]];
+		 skill - skill id number (see /sdk/skills.txt)
+		 count - maximum number of skill points to allocate for that skill
+		 satisfy - boolean value to stop(true) or continue(false) further allocation until count is met. Defaults to true if not specified.
+
+		 See Templates/AutoSkillExampleBuilds.txt for Config.AutoSkill.Build examples.
+
+		***AutoStat will stat in the order of precedence. You may want to stat strength or dexterity first to meet item requirements.
+
+		Format: Config.AutoStat.Build = [[statType, stat], [statType, stat], ... [statType, stat]];
+		 statType - defined as string, or as corresponding stat integer. "strength" or 0, "dexterity" or 2, "vitality" or 3, "energy" or 1
+		 stat - set to an integer value, and it will spend stat points until it reaches desired *hard stat value (*+stats from items are ignored).
+		 You can also set stat to string value "all", and it will spend all the remaining points.
+		 Dexterity can be set to "block" and it will stat dexterity up the the desired block value specified in arguemnt (ignored in classic).
+
+		 See Templates/AutoStatExampleBuilds.txt for Config.AutoStat.Build examples. 
+	*/
+	Config.AutoSkill.Enabled = false; // Enable or disable AutoSkill system
+	Config.AutoSkill.Save = 0; // Number of skill points that will not be spent and saved
+	Config.AutoSkill.Build = [];
+
+	Config.AutoStat.Enabled = false; // Enable or disable AutoStat system
+	Config.AutoStat.Save = 0; // Number stat points that will not be spent and saved.
+	Config.AutoStat.BlockChance = 0; // An integer value set to desired block chance. This is ignored in classic.
+	Config.AutoStat.UseBulk = true; // Set true to spend multiple stat points at once (up to 100), or false to spend singe point at a time.
+	Config.AutoStat.Build = [];
 
 	// AutoBuild System ( See /d2bs/kolbot/libs/config/Builds/README.txt for instructions )
 	Config.AutoBuild.Enabled = false;			//	This will enable or disable the AutoBuild system

--- a/d2bs/kolbot/libs/config/Barbarian.js
+++ b/d2bs/kolbot/libs/config/Barbarian.js
@@ -505,32 +505,31 @@ function LoadConfig() {
 	Config.FindItem = false; // Use Find Item skill on corpses after clearing.
 	Config.FindItemSwitch = 0; // Find Item weapon slot - 0 = slot I, 1 = slot II
 
-	/*	AutoStat and AutoSkill system builds character based on array defined by the user
-		When enabled, this system will replace AutoBuild's skill/stat system respectively. So please make sure to configure Build array.
-
-		***AutoSkill will automatically spend skill points and it can also allocate any prerequisite skills as required.
-
-		Format: Config.AutoSkill.Build = [[skillID, count, satisfy], [skillID, count, satisfy], ... [skillID, count, satisfy]];
-		 skill - skill id number (see /sdk/skills.txt)
-		 count - maximum number of skill points to allocate for that skill
-		 satisfy - boolean value to stop(true) or continue(false) further allocation until count is met. Defaults to true if not specified.
-
-		 See Templates/AutoSkillExampleBuilds.txt for Config.AutoSkill.Build examples.
-
-		***AutoStat will stat in the order of precedence. You may want to stat strength or dexterity first to meet item requirements.
-
-		Format: Config.AutoStat.Build = [[statType, stat], [statType, stat], ... [statType, stat]];
-		 statType - defined as string, or as corresponding stat integer. "strength" or 0, "dexterity" or 2, "vitality" or 3, "energy" or 1
-		 stat - set to an integer value, and it will spend stat points until it reaches desired *hard stat value (*+stats from items are ignored).
-		 You can also set stat to string value "all", and it will spend all the remaining points.
-		 Dexterity can be set to "block" and it will stat dexterity up the the desired block value specified in arguemnt (ignored in classic).
-
-		 See Templates/AutoStatExampleBuilds.txt for Config.AutoStat.Build examples. 
-	*/
+	/* AutoSkill builds character based on array defined by the user and it replaces AutoBuild's skill system.
+	 * AutoSkill will automatically spend skill points and it can also allocate any prerequisite skills as required.
+     *
+	 * Format: Config.AutoSkill.Build = [[skillID, count, satisfy], [skillID, count, satisfy], ... [skillID, count, satisfy]];
+	 *	skill - skill id number (see /sdk/skills.txt)
+	 *	count - maximum number of skill points to allocate for that skill
+	 *	satisfy - boolean value to stop(true) or continue(false) further allocation until count is met. Defaults to true if not specified.
+     *
+	 *	See libs/config/Templates/AutoSkillExampleBuilds.txt for Config.AutoSkill.Build examples.
+	 */
 	Config.AutoSkill.Enabled = false; // Enable or disable AutoSkill system
 	Config.AutoSkill.Save = 0; // Number of skill points that will not be spent and saved
 	Config.AutoSkill.Build = [];
 
+	/* AutoStat builds character based on array defined by the user and this will replace AutoBuild's stat system.
+	 * AutoStat will stat Build array order. You may want to stat strength or dexterity first to meet item requirements.
+     *
+	 * Format: Config.AutoStat.Build = [[statType, stat], [statType, stat], ... [statType, stat]];
+	 *	statType - defined as string, or as corresponding stat integer. "strength" or 0, "dexterity" or 2, "vitality" or 3, "energy" or 1
+	 *	stat - set to an integer value, and it will spend stat points until it reaches desired *hard stat value (*+stats from items are ignored).
+	 *	You can also set stat to string value "all", and it will spend all the remaining points.
+	 *	Dexterity can be set to "block" and it will stat dexterity up the the desired block value specified in arguemnt (ignored in classic).
+     *
+	 *	See libs/config/Templates/AutoStatExampleBuilds.txt for Config.AutoStat.Build examples. 
+	 */
 	Config.AutoStat.Enabled = false; // Enable or disable AutoStat system
 	Config.AutoStat.Save = 0; // Number stat points that will not be spent and saved.
 	Config.AutoStat.BlockChance = 0; // An integer value set to desired block chance. This is ignored in classic.

--- a/d2bs/kolbot/libs/config/Barbarian.js
+++ b/d2bs/kolbot/libs/config/Barbarian.js
@@ -507,12 +507,12 @@ function LoadConfig() {
 
 	/* AutoSkill builds character based on array defined by the user and it replaces AutoBuild's skill system.
 	 * AutoSkill will automatically spend skill points and it can also allocate any prerequisite skills as required.
-     *
+	 *
 	 * Format: Config.AutoSkill.Build = [[skillID, count, satisfy], [skillID, count, satisfy], ... [skillID, count, satisfy]];
 	 *	skill - skill id number (see /sdk/skills.txt)
 	 *	count - maximum number of skill points to allocate for that skill
 	 *	satisfy - boolean value to stop(true) or continue(false) further allocation until count is met. Defaults to true if not specified.
-     *
+	 *
 	 *	See libs/config/Templates/AutoSkillExampleBuilds.txt for Config.AutoSkill.Build examples.
 	 */
 	Config.AutoSkill.Enabled = false; // Enable or disable AutoSkill system
@@ -521,13 +521,13 @@ function LoadConfig() {
 
 	/* AutoStat builds character based on array defined by the user and this will replace AutoBuild's stat system.
 	 * AutoStat will stat Build array order. You may want to stat strength or dexterity first to meet item requirements.
-     *
+	 *
 	 * Format: Config.AutoStat.Build = [[statType, stat], [statType, stat], ... [statType, stat]];
 	 *	statType - defined as string, or as corresponding stat integer. "strength" or 0, "dexterity" or 2, "vitality" or 3, "energy" or 1
 	 *	stat - set to an integer value, and it will spend stat points until it reaches desired *hard stat value (*+stats from items are ignored).
 	 *	You can also set stat to string value "all", and it will spend all the remaining points.
 	 *	Dexterity can be set to "block" and it will stat dexterity up the the desired block value specified in arguemnt (ignored in classic).
-     *
+	 *
 	 *	See libs/config/Templates/AutoStatExampleBuilds.txt for Config.AutoStat.Build examples. 
 	 */
 	Config.AutoStat.Enabled = false; // Enable or disable AutoStat system

--- a/d2bs/kolbot/libs/config/Druid.js
+++ b/d2bs/kolbot/libs/config/Druid.js
@@ -511,6 +511,37 @@ function LoadConfig() {
 	Config.SummonSpirit = "Oak Sage"; // 0 = disabled, 1 / "Oak Sage", 2 / "Heart of Wolverine", 3 / "Spirit of Barbs"
 	Config.SummonVine = "Poison Creeper"; // 0 = disabled, 1 / "Poison Creeper", 2 / "Carrion Vine", 3 / "Solar Creeper"
 
+	/*	AutoStat and AutoSkill system builds character based on array defined by the user
+		When enabled, this system will replace AutoBuild's skill/stat system respectively. So please make sure to configure Build array.
+
+		***AutoSkill will automatically spend skill points and it can also allocate any prerequisite skills as required.
+
+		Format: Config.AutoSkill.Build = [[skillID, count, satisfy], [skillID, count, satisfy], ... [skillID, count, satisfy]];
+		 skill - skill id number (see /sdk/skills.txt)
+		 count - maximum number of skill points to allocate for that skill
+		 satisfy - boolean value to stop(true) or continue(false) further allocation until count is met. Defaults to true if not specified.
+
+		 See Templates/AutoSkillExampleBuilds.txt for Config.AutoSkill.Build examples.
+
+		***AutoStat will stat in the order of precedence. You may want to stat strength or dexterity first to meet item requirements.
+
+		Format: Config.AutoStat.Build = [[statType, stat], [statType, stat], ... [statType, stat]];
+		 statType - defined as string, or as corresponding stat integer. "strength" or 0, "dexterity" or 2, "vitality" or 3, "energy" or 1
+		 stat - set to an integer value, and it will spend stat points until it reaches desired *hard stat value (*+stats from items are ignored).
+		 You can also set stat to string value "all", and it will spend all the remaining points.
+		 Dexterity can be set to "block" and it will stat dexterity up the the desired block value specified in arguemnt (ignored in classic).
+
+		 See Templates/AutoStatExampleBuilds.txt for Config.AutoStat.Build examples. 
+	*/
+	Config.AutoSkill.Enabled = false; // Enable or disable AutoSkill system
+	Config.AutoSkill.Save = 0; // Number of skill points that will not be spent and saved
+	Config.AutoSkill.Build = [];
+
+	Config.AutoStat.Enabled = false; // Enable or disable AutoStat system
+	Config.AutoStat.Save = 0; // Number stat points that will not be spent and saved.
+	Config.AutoStat.BlockChance = 0; // An integer value set to desired block chance. This is ignored in classic.
+	Config.AutoStat.UseBulk = true; // Set true to spend multiple stat points at once (up to 100), or false to spend singe point at a time.
+	Config.AutoStat.Build = [];
 
 	// AutoBuild System ( See /d2bs/kolbot/libs/config/Builds/README.txt for instructions )
 	Config.AutoBuild.Enabled = false;			//	This will enable or disable the AutoBuild system

--- a/d2bs/kolbot/libs/config/Druid.js
+++ b/d2bs/kolbot/libs/config/Druid.js
@@ -511,32 +511,31 @@ function LoadConfig() {
 	Config.SummonSpirit = "Oak Sage"; // 0 = disabled, 1 / "Oak Sage", 2 / "Heart of Wolverine", 3 / "Spirit of Barbs"
 	Config.SummonVine = "Poison Creeper"; // 0 = disabled, 1 / "Poison Creeper", 2 / "Carrion Vine", 3 / "Solar Creeper"
 
-	/*	AutoStat and AutoSkill system builds character based on array defined by the user
-		When enabled, this system will replace AutoBuild's skill/stat system respectively. So please make sure to configure Build array.
-
-		***AutoSkill will automatically spend skill points and it can also allocate any prerequisite skills as required.
-
-		Format: Config.AutoSkill.Build = [[skillID, count, satisfy], [skillID, count, satisfy], ... [skillID, count, satisfy]];
-		 skill - skill id number (see /sdk/skills.txt)
-		 count - maximum number of skill points to allocate for that skill
-		 satisfy - boolean value to stop(true) or continue(false) further allocation until count is met. Defaults to true if not specified.
-
-		 See Templates/AutoSkillExampleBuilds.txt for Config.AutoSkill.Build examples.
-
-		***AutoStat will stat in the order of precedence. You may want to stat strength or dexterity first to meet item requirements.
-
-		Format: Config.AutoStat.Build = [[statType, stat], [statType, stat], ... [statType, stat]];
-		 statType - defined as string, or as corresponding stat integer. "strength" or 0, "dexterity" or 2, "vitality" or 3, "energy" or 1
-		 stat - set to an integer value, and it will spend stat points until it reaches desired *hard stat value (*+stats from items are ignored).
-		 You can also set stat to string value "all", and it will spend all the remaining points.
-		 Dexterity can be set to "block" and it will stat dexterity up the the desired block value specified in arguemnt (ignored in classic).
-
-		 See Templates/AutoStatExampleBuilds.txt for Config.AutoStat.Build examples. 
-	*/
+	/* AutoSkill builds character based on array defined by the user and it replaces AutoBuild's skill system.
+	 * AutoSkill will automatically spend skill points and it can also allocate any prerequisite skills as required.
+     *
+	 * Format: Config.AutoSkill.Build = [[skillID, count, satisfy], [skillID, count, satisfy], ... [skillID, count, satisfy]];
+	 *	skill - skill id number (see /sdk/skills.txt)
+	 *	count - maximum number of skill points to allocate for that skill
+	 *	satisfy - boolean value to stop(true) or continue(false) further allocation until count is met. Defaults to true if not specified.
+     *
+	 *	See libs/config/Templates/AutoSkillExampleBuilds.txt for Config.AutoSkill.Build examples.
+	 */
 	Config.AutoSkill.Enabled = false; // Enable or disable AutoSkill system
 	Config.AutoSkill.Save = 0; // Number of skill points that will not be spent and saved
 	Config.AutoSkill.Build = [];
 
+	/* AutoStat builds character based on array defined by the user and this will replace AutoBuild's stat system.
+	 * AutoStat will stat Build array order. You may want to stat strength or dexterity first to meet item requirements.
+     *
+	 * Format: Config.AutoStat.Build = [[statType, stat], [statType, stat], ... [statType, stat]];
+	 *	statType - defined as string, or as corresponding stat integer. "strength" or 0, "dexterity" or 2, "vitality" or 3, "energy" or 1
+	 *	stat - set to an integer value, and it will spend stat points until it reaches desired *hard stat value (*+stats from items are ignored).
+	 *	You can also set stat to string value "all", and it will spend all the remaining points.
+	 *	Dexterity can be set to "block" and it will stat dexterity up the the desired block value specified in arguemnt (ignored in classic).
+     *
+	 *	See libs/config/Templates/AutoStatExampleBuilds.txt for Config.AutoStat.Build examples. 
+	 */
 	Config.AutoStat.Enabled = false; // Enable or disable AutoStat system
 	Config.AutoStat.Save = 0; // Number stat points that will not be spent and saved.
 	Config.AutoStat.BlockChance = 0; // An integer value set to desired block chance. This is ignored in classic.

--- a/d2bs/kolbot/libs/config/Druid.js
+++ b/d2bs/kolbot/libs/config/Druid.js
@@ -513,12 +513,12 @@ function LoadConfig() {
 
 	/* AutoSkill builds character based on array defined by the user and it replaces AutoBuild's skill system.
 	 * AutoSkill will automatically spend skill points and it can also allocate any prerequisite skills as required.
-     *
+	 *
 	 * Format: Config.AutoSkill.Build = [[skillID, count, satisfy], [skillID, count, satisfy], ... [skillID, count, satisfy]];
 	 *	skill - skill id number (see /sdk/skills.txt)
 	 *	count - maximum number of skill points to allocate for that skill
 	 *	satisfy - boolean value to stop(true) or continue(false) further allocation until count is met. Defaults to true if not specified.
-     *
+	 *
 	 *	See libs/config/Templates/AutoSkillExampleBuilds.txt for Config.AutoSkill.Build examples.
 	 */
 	Config.AutoSkill.Enabled = false; // Enable or disable AutoSkill system
@@ -527,13 +527,13 @@ function LoadConfig() {
 
 	/* AutoStat builds character based on array defined by the user and this will replace AutoBuild's stat system.
 	 * AutoStat will stat Build array order. You may want to stat strength or dexterity first to meet item requirements.
-     *
+	 *
 	 * Format: Config.AutoStat.Build = [[statType, stat], [statType, stat], ... [statType, stat]];
 	 *	statType - defined as string, or as corresponding stat integer. "strength" or 0, "dexterity" or 2, "vitality" or 3, "energy" or 1
 	 *	stat - set to an integer value, and it will spend stat points until it reaches desired *hard stat value (*+stats from items are ignored).
 	 *	You can also set stat to string value "all", and it will spend all the remaining points.
 	 *	Dexterity can be set to "block" and it will stat dexterity up the the desired block value specified in arguemnt (ignored in classic).
-     *
+	 *
 	 *	See libs/config/Templates/AutoStatExampleBuilds.txt for Config.AutoStat.Build examples. 
 	 */
 	Config.AutoStat.Enabled = false; // Enable or disable AutoStat system

--- a/d2bs/kolbot/libs/config/Necromancer.js
+++ b/d2bs/kolbot/libs/config/Necromancer.js
@@ -522,6 +522,37 @@ function LoadConfig() {
 	Config.ReviveUnstackable = true; // Revive monsters that can move freely after you teleport.
 	Config.IronGolemChicken = 30; // Exit game if Iron Golem's life is less or equal to designated percent.
 
+	/*	AutoStat and AutoSkill system builds character based on array defined by the user
+		When enabled, this system will replace AutoBuild's skill/stat system respectively. So please make sure to configure Build array.
+
+		***AutoSkill will automatically spend skill points and it can also allocate any prerequisite skills as required.
+
+		Format: Config.AutoSkill.Build = [[skillID, count, satisfy], [skillID, count, satisfy], ... [skillID, count, satisfy]];
+		 skill - skill id number (see /sdk/skills.txt)
+		 count - maximum number of skill points to allocate for that skill
+		 satisfy - boolean value to stop(true) or continue(false) further allocation until count is met. Defaults to true if not specified.
+
+		 See Templates/AutoSkillExampleBuilds.txt for Config.AutoSkill.Build examples.
+
+		***AutoStat will stat in the order of precedence. You may want to stat strength or dexterity first to meet item requirements.
+
+		Format: Config.AutoStat.Build = [[statType, stat], [statType, stat], ... [statType, stat]];
+		 statType - defined as string, or as corresponding stat integer. "strength" or 0, "dexterity" or 2, "vitality" or 3, "energy" or 1
+		 stat - set to an integer value, and it will spend stat points until it reaches desired *hard stat value (*+stats from items are ignored).
+		 You can also set stat to string value "all", and it will spend all the remaining points.
+		 Dexterity can be set to "block" and it will stat dexterity up the the desired block value specified in arguemnt (ignored in classic).
+
+		 See Templates/AutoStatExampleBuilds.txt for Config.AutoStat.Build examples. 
+	*/
+	Config.AutoSkill.Enabled = false; // Enable or disable AutoSkill system
+	Config.AutoSkill.Save = 0; // Number of skill points that will not be spent and saved
+	Config.AutoSkill.Build = [];
+
+	Config.AutoStat.Enabled = false; // Enable or disable AutoStat system
+	Config.AutoStat.Save = 0; // Number stat points that will not be spent and saved.
+	Config.AutoStat.BlockChance = 0; // An integer value set to desired block chance. This is ignored in classic.
+	Config.AutoStat.UseBulk = true; // Set true to spend multiple stat points at once (up to 100), or false to spend singe point at a time.
+	Config.AutoStat.Build = [];
 
 	// AutoBuild System ( See /d2bs/kolbot/libs/config/Builds/README.txt for instructions )
 	Config.AutoBuild.Enabled = false;			//	This will enable or disable the AutoBuild system

--- a/d2bs/kolbot/libs/config/Necromancer.js
+++ b/d2bs/kolbot/libs/config/Necromancer.js
@@ -524,12 +524,12 @@ function LoadConfig() {
 
 	/* AutoSkill builds character based on array defined by the user and it replaces AutoBuild's skill system.
 	 * AutoSkill will automatically spend skill points and it can also allocate any prerequisite skills as required.
-     *
+	 *
 	 * Format: Config.AutoSkill.Build = [[skillID, count, satisfy], [skillID, count, satisfy], ... [skillID, count, satisfy]];
 	 *	skill - skill id number (see /sdk/skills.txt)
 	 *	count - maximum number of skill points to allocate for that skill
 	 *	satisfy - boolean value to stop(true) or continue(false) further allocation until count is met. Defaults to true if not specified.
-     *
+	 *
 	 *	See libs/config/Templates/AutoSkillExampleBuilds.txt for Config.AutoSkill.Build examples.
 	 */
 	Config.AutoSkill.Enabled = false; // Enable or disable AutoSkill system
@@ -538,13 +538,13 @@ function LoadConfig() {
 
 	/* AutoStat builds character based on array defined by the user and this will replace AutoBuild's stat system.
 	 * AutoStat will stat Build array order. You may want to stat strength or dexterity first to meet item requirements.
-     *
+	 *
 	 * Format: Config.AutoStat.Build = [[statType, stat], [statType, stat], ... [statType, stat]];
 	 *	statType - defined as string, or as corresponding stat integer. "strength" or 0, "dexterity" or 2, "vitality" or 3, "energy" or 1
 	 *	stat - set to an integer value, and it will spend stat points until it reaches desired *hard stat value (*+stats from items are ignored).
 	 *	You can also set stat to string value "all", and it will spend all the remaining points.
 	 *	Dexterity can be set to "block" and it will stat dexterity up the the desired block value specified in arguemnt (ignored in classic).
-     *
+	 *
 	 *	See libs/config/Templates/AutoStatExampleBuilds.txt for Config.AutoStat.Build examples. 
 	 */
 	Config.AutoStat.Enabled = false; // Enable or disable AutoStat system

--- a/d2bs/kolbot/libs/config/Necromancer.js
+++ b/d2bs/kolbot/libs/config/Necromancer.js
@@ -522,32 +522,31 @@ function LoadConfig() {
 	Config.ReviveUnstackable = true; // Revive monsters that can move freely after you teleport.
 	Config.IronGolemChicken = 30; // Exit game if Iron Golem's life is less or equal to designated percent.
 
-	/*	AutoStat and AutoSkill system builds character based on array defined by the user
-		When enabled, this system will replace AutoBuild's skill/stat system respectively. So please make sure to configure Build array.
-
-		***AutoSkill will automatically spend skill points and it can also allocate any prerequisite skills as required.
-
-		Format: Config.AutoSkill.Build = [[skillID, count, satisfy], [skillID, count, satisfy], ... [skillID, count, satisfy]];
-		 skill - skill id number (see /sdk/skills.txt)
-		 count - maximum number of skill points to allocate for that skill
-		 satisfy - boolean value to stop(true) or continue(false) further allocation until count is met. Defaults to true if not specified.
-
-		 See Templates/AutoSkillExampleBuilds.txt for Config.AutoSkill.Build examples.
-
-		***AutoStat will stat in the order of precedence. You may want to stat strength or dexterity first to meet item requirements.
-
-		Format: Config.AutoStat.Build = [[statType, stat], [statType, stat], ... [statType, stat]];
-		 statType - defined as string, or as corresponding stat integer. "strength" or 0, "dexterity" or 2, "vitality" or 3, "energy" or 1
-		 stat - set to an integer value, and it will spend stat points until it reaches desired *hard stat value (*+stats from items are ignored).
-		 You can also set stat to string value "all", and it will spend all the remaining points.
-		 Dexterity can be set to "block" and it will stat dexterity up the the desired block value specified in arguemnt (ignored in classic).
-
-		 See Templates/AutoStatExampleBuilds.txt for Config.AutoStat.Build examples. 
-	*/
+	/* AutoSkill builds character based on array defined by the user and it replaces AutoBuild's skill system.
+	 * AutoSkill will automatically spend skill points and it can also allocate any prerequisite skills as required.
+     *
+	 * Format: Config.AutoSkill.Build = [[skillID, count, satisfy], [skillID, count, satisfy], ... [skillID, count, satisfy]];
+	 *	skill - skill id number (see /sdk/skills.txt)
+	 *	count - maximum number of skill points to allocate for that skill
+	 *	satisfy - boolean value to stop(true) or continue(false) further allocation until count is met. Defaults to true if not specified.
+     *
+	 *	See libs/config/Templates/AutoSkillExampleBuilds.txt for Config.AutoSkill.Build examples.
+	 */
 	Config.AutoSkill.Enabled = false; // Enable or disable AutoSkill system
 	Config.AutoSkill.Save = 0; // Number of skill points that will not be spent and saved
 	Config.AutoSkill.Build = [];
 
+	/* AutoStat builds character based on array defined by the user and this will replace AutoBuild's stat system.
+	 * AutoStat will stat Build array order. You may want to stat strength or dexterity first to meet item requirements.
+     *
+	 * Format: Config.AutoStat.Build = [[statType, stat], [statType, stat], ... [statType, stat]];
+	 *	statType - defined as string, or as corresponding stat integer. "strength" or 0, "dexterity" or 2, "vitality" or 3, "energy" or 1
+	 *	stat - set to an integer value, and it will spend stat points until it reaches desired *hard stat value (*+stats from items are ignored).
+	 *	You can also set stat to string value "all", and it will spend all the remaining points.
+	 *	Dexterity can be set to "block" and it will stat dexterity up the the desired block value specified in arguemnt (ignored in classic).
+     *
+	 *	See libs/config/Templates/AutoStatExampleBuilds.txt for Config.AutoStat.Build examples. 
+	 */
 	Config.AutoStat.Enabled = false; // Enable or disable AutoStat system
 	Config.AutoStat.Save = 0; // Number stat points that will not be spent and saved.
 	Config.AutoStat.BlockChance = 0; // An integer value set to desired block chance. This is ignored in classic.

--- a/d2bs/kolbot/libs/config/Paladin.js
+++ b/d2bs/kolbot/libs/config/Paladin.js
@@ -512,12 +512,12 @@ function LoadConfig() {
 
 	/* AutoSkill builds character based on array defined by the user and it replaces AutoBuild's skill system.
 	 * AutoSkill will automatically spend skill points and it can also allocate any prerequisite skills as required.
-     *
+	 *
 	 * Format: Config.AutoSkill.Build = [[skillID, count, satisfy], [skillID, count, satisfy], ... [skillID, count, satisfy]];
 	 *	skill - skill id number (see /sdk/skills.txt)
 	 *	count - maximum number of skill points to allocate for that skill
 	 *	satisfy - boolean value to stop(true) or continue(false) further allocation until count is met. Defaults to true if not specified.
-     *
+	 *
 	 *	See libs/config/Templates/AutoSkillExampleBuilds.txt for Config.AutoSkill.Build examples.
 	 */
 	Config.AutoSkill.Enabled = false; // Enable or disable AutoSkill system
@@ -526,13 +526,13 @@ function LoadConfig() {
 
 	/* AutoStat builds character based on array defined by the user and this will replace AutoBuild's stat system.
 	 * AutoStat will stat Build array order. You may want to stat strength or dexterity first to meet item requirements.
-     *
+	 *
 	 * Format: Config.AutoStat.Build = [[statType, stat], [statType, stat], ... [statType, stat]];
 	 *	statType - defined as string, or as corresponding stat integer. "strength" or 0, "dexterity" or 2, "vitality" or 3, "energy" or 1
 	 *	stat - set to an integer value, and it will spend stat points until it reaches desired *hard stat value (*+stats from items are ignored).
 	 *	You can also set stat to string value "all", and it will spend all the remaining points.
 	 *	Dexterity can be set to "block" and it will stat dexterity up the the desired block value specified in arguemnt (ignored in classic).
-     *
+	 *
 	 *	See libs/config/Templates/AutoStatExampleBuilds.txt for Config.AutoStat.Build examples. 
 	 */
 	Config.AutoStat.Enabled = false; // Enable or disable AutoStat system

--- a/d2bs/kolbot/libs/config/Paladin.js
+++ b/d2bs/kolbot/libs/config/Paladin.js
@@ -510,6 +510,37 @@ function LoadConfig() {
 	Config.Charge = true; // Use Charge when running
 	Config.Redemption = [50, 50]; // Switch to Redemption after clearing an area if under designated life or mana. Format: [lifepercent, manapercent]
 
+	/*	AutoStat and AutoSkill system builds character based on array defined by the user
+		When enabled, this system will replace AutoBuild's skill/stat system respectively. So please make sure to configure Build array.
+
+		***AutoSkill will automatically spend skill points and it can also allocate any prerequisite skills as required.
+
+		Format: Config.AutoSkill.Build = [[skillID, count, satisfy], [skillID, count, satisfy], ... [skillID, count, satisfy]];
+		 skill - skill id number (see /sdk/skills.txt)
+		 count - maximum number of skill points to allocate for that skill
+		 satisfy - boolean value to stop(true) or continue(false) further allocation until count is met. Defaults to true if not specified.
+
+		 See Templates/AutoSkillExampleBuilds.txt for Config.AutoSkill.Build examples.
+
+		***AutoStat will stat in the order of precedence. You may want to stat strength or dexterity first to meet item requirements.
+
+		Format: Config.AutoStat.Build = [[statType, stat], [statType, stat], ... [statType, stat]];
+		 statType - defined as string, or as corresponding stat integer. "strength" or 0, "dexterity" or 2, "vitality" or 3, "energy" or 1
+		 stat - set to an integer value, and it will spend stat points until it reaches desired *hard stat value (*+stats from items are ignored).
+		 You can also set stat to string value "all", and it will spend all the remaining points.
+		 Dexterity can be set to "block" and it will stat dexterity up the the desired block value specified in arguemnt (ignored in classic).
+
+		 See Templates/AutoStatExampleBuilds.txt for Config.AutoStat.Build examples. 
+	*/
+	Config.AutoSkill.Enabled = false; // Enable or disable AutoSkill system
+	Config.AutoSkill.Save = 0; // Number of skill points that will not be spent and saved
+	Config.AutoSkill.Build = [];
+
+	Config.AutoStat.Enabled = false; // Enable or disable AutoStat system
+	Config.AutoStat.Save = 0; // Number stat points that will not be spent and saved.
+	Config.AutoStat.BlockChance = 0; // An integer value set to desired block chance. This is ignored in classic.
+	Config.AutoStat.UseBulk = true; // Set true to spend multiple stat points at once (up to 100), or false to spend singe point at a time.
+	Config.AutoStat.Build = [];
 
 	// AutoBuild System ( See /d2bs/kolbot/libs/config/Builds/README.txt for instructions )
 	Config.AutoBuild.Enabled = false;			//	This will enable or disable the AutoBuild system

--- a/d2bs/kolbot/libs/config/Paladin.js
+++ b/d2bs/kolbot/libs/config/Paladin.js
@@ -510,32 +510,31 @@ function LoadConfig() {
 	Config.Charge = true; // Use Charge when running
 	Config.Redemption = [50, 50]; // Switch to Redemption after clearing an area if under designated life or mana. Format: [lifepercent, manapercent]
 
-	/*	AutoStat and AutoSkill system builds character based on array defined by the user
-		When enabled, this system will replace AutoBuild's skill/stat system respectively. So please make sure to configure Build array.
-
-		***AutoSkill will automatically spend skill points and it can also allocate any prerequisite skills as required.
-
-		Format: Config.AutoSkill.Build = [[skillID, count, satisfy], [skillID, count, satisfy], ... [skillID, count, satisfy]];
-		 skill - skill id number (see /sdk/skills.txt)
-		 count - maximum number of skill points to allocate for that skill
-		 satisfy - boolean value to stop(true) or continue(false) further allocation until count is met. Defaults to true if not specified.
-
-		 See Templates/AutoSkillExampleBuilds.txt for Config.AutoSkill.Build examples.
-
-		***AutoStat will stat in the order of precedence. You may want to stat strength or dexterity first to meet item requirements.
-
-		Format: Config.AutoStat.Build = [[statType, stat], [statType, stat], ... [statType, stat]];
-		 statType - defined as string, or as corresponding stat integer. "strength" or 0, "dexterity" or 2, "vitality" or 3, "energy" or 1
-		 stat - set to an integer value, and it will spend stat points until it reaches desired *hard stat value (*+stats from items are ignored).
-		 You can also set stat to string value "all", and it will spend all the remaining points.
-		 Dexterity can be set to "block" and it will stat dexterity up the the desired block value specified in arguemnt (ignored in classic).
-
-		 See Templates/AutoStatExampleBuilds.txt for Config.AutoStat.Build examples. 
-	*/
+	/* AutoSkill builds character based on array defined by the user and it replaces AutoBuild's skill system.
+	 * AutoSkill will automatically spend skill points and it can also allocate any prerequisite skills as required.
+     *
+	 * Format: Config.AutoSkill.Build = [[skillID, count, satisfy], [skillID, count, satisfy], ... [skillID, count, satisfy]];
+	 *	skill - skill id number (see /sdk/skills.txt)
+	 *	count - maximum number of skill points to allocate for that skill
+	 *	satisfy - boolean value to stop(true) or continue(false) further allocation until count is met. Defaults to true if not specified.
+     *
+	 *	See libs/config/Templates/AutoSkillExampleBuilds.txt for Config.AutoSkill.Build examples.
+	 */
 	Config.AutoSkill.Enabled = false; // Enable or disable AutoSkill system
 	Config.AutoSkill.Save = 0; // Number of skill points that will not be spent and saved
 	Config.AutoSkill.Build = [];
 
+	/* AutoStat builds character based on array defined by the user and this will replace AutoBuild's stat system.
+	 * AutoStat will stat Build array order. You may want to stat strength or dexterity first to meet item requirements.
+     *
+	 * Format: Config.AutoStat.Build = [[statType, stat], [statType, stat], ... [statType, stat]];
+	 *	statType - defined as string, or as corresponding stat integer. "strength" or 0, "dexterity" or 2, "vitality" or 3, "energy" or 1
+	 *	stat - set to an integer value, and it will spend stat points until it reaches desired *hard stat value (*+stats from items are ignored).
+	 *	You can also set stat to string value "all", and it will spend all the remaining points.
+	 *	Dexterity can be set to "block" and it will stat dexterity up the the desired block value specified in arguemnt (ignored in classic).
+     *
+	 *	See libs/config/Templates/AutoStatExampleBuilds.txt for Config.AutoStat.Build examples. 
+	 */
 	Config.AutoStat.Enabled = false; // Enable or disable AutoStat system
 	Config.AutoStat.Save = 0; // Number stat points that will not be spent and saved.
 	Config.AutoStat.BlockChance = 0; // An integer value set to desired block chance. This is ignored in classic.

--- a/d2bs/kolbot/libs/config/Sorceress.js
+++ b/d2bs/kolbot/libs/config/Sorceress.js
@@ -513,32 +513,31 @@ function LoadConfig() {
 	Config.CastStatic = 60; // Cast static until the target is at designated life percent. 100 = disabled.
 	Config.StaticList = []; // List of monster NAMES or CLASSIDS to static. Example: Config.StaticList = ["Andariel", 243];
 
-	/*	AutoStat and AutoSkill system builds character based on array defined by the user
-		When enabled, this system will replace AutoBuild's skill/stat system respectively. So please make sure to configure Build array.
-
-		***AutoSkill will automatically spend skill points and it can also allocate any prerequisite skills as required.
-
-		Format: Config.AutoSkill.Build = [[skillID, count, satisfy], [skillID, count, satisfy], ... [skillID, count, satisfy]];
-		 skill - skill id number (see /sdk/skills.txt)
-		 count - maximum number of skill points to allocate for that skill
-		 satisfy - boolean value to stop(true) or continue(false) further allocation until count is met. Defaults to true if not specified.
-
-		 See Templates/AutoSkillExampleBuilds.txt for Config.AutoSkill.Build examples.
-
-		***AutoStat will stat in the order of precedence. You may want to stat strength or dexterity first to meet item requirements.
-
-		Format: Config.AutoStat.Build = [[statType, stat], [statType, stat], ... [statType, stat]];
-		 statType - defined as string, or as corresponding stat integer. "strength" or 0, "dexterity" or 2, "vitality" or 3, "energy" or 1
-		 stat - set to an integer value, and it will spend stat points until it reaches desired *hard stat value (*+stats from items are ignored).
-		 You can also set stat to string value "all", and it will spend all the remaining points.
-		 Dexterity can be set to "block" and it will stat dexterity up the the desired block value specified in arguemnt (ignored in classic).
-
-		 See Templates/AutoStatExampleBuilds.txt for Config.AutoStat.Build examples. 
-	*/
+	/* AutoSkill builds character based on array defined by the user and it replaces AutoBuild's skill system.
+	 * AutoSkill will automatically spend skill points and it can also allocate any prerequisite skills as required.
+     *
+	 * Format: Config.AutoSkill.Build = [[skillID, count, satisfy], [skillID, count, satisfy], ... [skillID, count, satisfy]];
+	 *	skill - skill id number (see /sdk/skills.txt)
+	 *	count - maximum number of skill points to allocate for that skill
+	 *	satisfy - boolean value to stop(true) or continue(false) further allocation until count is met. Defaults to true if not specified.
+     *
+	 *	See libs/config/Templates/AutoSkillExampleBuilds.txt for Config.AutoSkill.Build examples.
+	 */
 	Config.AutoSkill.Enabled = false; // Enable or disable AutoSkill system
 	Config.AutoSkill.Save = 0; // Number of skill points that will not be spent and saved
 	Config.AutoSkill.Build = [];
 
+	/* AutoStat builds character based on array defined by the user and this will replace AutoBuild's stat system.
+	 * AutoStat will stat Build array order. You may want to stat strength or dexterity first to meet item requirements.
+     *
+	 * Format: Config.AutoStat.Build = [[statType, stat], [statType, stat], ... [statType, stat]];
+	 *	statType - defined as string, or as corresponding stat integer. "strength" or 0, "dexterity" or 2, "vitality" or 3, "energy" or 1
+	 *	stat - set to an integer value, and it will spend stat points until it reaches desired *hard stat value (*+stats from items are ignored).
+	 *	You can also set stat to string value "all", and it will spend all the remaining points.
+	 *	Dexterity can be set to "block" and it will stat dexterity up the the desired block value specified in arguemnt (ignored in classic).
+     *
+	 *	See libs/config/Templates/AutoStatExampleBuilds.txt for Config.AutoStat.Build examples. 
+	 */
 	Config.AutoStat.Enabled = false; // Enable or disable AutoStat system
 	Config.AutoStat.Save = 0; // Number stat points that will not be spent and saved.
 	Config.AutoStat.BlockChance = 0; // An integer value set to desired block chance. This is ignored in classic.

--- a/d2bs/kolbot/libs/config/Sorceress.js
+++ b/d2bs/kolbot/libs/config/Sorceress.js
@@ -513,6 +513,37 @@ function LoadConfig() {
 	Config.CastStatic = 60; // Cast static until the target is at designated life percent. 100 = disabled.
 	Config.StaticList = []; // List of monster NAMES or CLASSIDS to static. Example: Config.StaticList = ["Andariel", 243];
 
+	/*	AutoStat and AutoSkill system builds character based on array defined by the user
+		When enabled, this system will replace AutoBuild's skill/stat system respectively. So please make sure to configure Build array.
+
+		***AutoSkill will automatically spend skill points and it can also allocate any prerequisite skills as required.
+
+		Format: Config.AutoSkill.Build = [[skillID, count, satisfy], [skillID, count, satisfy], ... [skillID, count, satisfy]];
+		 skill - skill id number (see /sdk/skills.txt)
+		 count - maximum number of skill points to allocate for that skill
+		 satisfy - boolean value to stop(true) or continue(false) further allocation until count is met. Defaults to true if not specified.
+
+		 See Templates/AutoSkillExampleBuilds.txt for Config.AutoSkill.Build examples.
+
+		***AutoStat will stat in the order of precedence. You may want to stat strength or dexterity first to meet item requirements.
+
+		Format: Config.AutoStat.Build = [[statType, stat], [statType, stat], ... [statType, stat]];
+		 statType - defined as string, or as corresponding stat integer. "strength" or 0, "dexterity" or 2, "vitality" or 3, "energy" or 1
+		 stat - set to an integer value, and it will spend stat points until it reaches desired *hard stat value (*+stats from items are ignored).
+		 You can also set stat to string value "all", and it will spend all the remaining points.
+		 Dexterity can be set to "block" and it will stat dexterity up the the desired block value specified in arguemnt (ignored in classic).
+
+		 See Templates/AutoStatExampleBuilds.txt for Config.AutoStat.Build examples. 
+	*/
+	Config.AutoSkill.Enabled = false; // Enable or disable AutoSkill system
+	Config.AutoSkill.Save = 0; // Number of skill points that will not be spent and saved
+	Config.AutoSkill.Build = [];
+
+	Config.AutoStat.Enabled = false; // Enable or disable AutoStat system
+	Config.AutoStat.Save = 0; // Number stat points that will not be spent and saved.
+	Config.AutoStat.BlockChance = 0; // An integer value set to desired block chance. This is ignored in classic.
+	Config.AutoStat.UseBulk = true; // Set true to spend multiple stat points at once (up to 100), or false to spend singe point at a time.
+	Config.AutoStat.Build = [];
 
 	// AutoBuild System ( See /d2bs/kolbot/libs/config/Builds/README.txt for instructions )
 	Config.AutoBuild.Enabled = false;			//	This will enable or disable the AutoBuild system

--- a/d2bs/kolbot/libs/config/Sorceress.js
+++ b/d2bs/kolbot/libs/config/Sorceress.js
@@ -515,12 +515,12 @@ function LoadConfig() {
 
 	/* AutoSkill builds character based on array defined by the user and it replaces AutoBuild's skill system.
 	 * AutoSkill will automatically spend skill points and it can also allocate any prerequisite skills as required.
-     *
+	 *
 	 * Format: Config.AutoSkill.Build = [[skillID, count, satisfy], [skillID, count, satisfy], ... [skillID, count, satisfy]];
 	 *	skill - skill id number (see /sdk/skills.txt)
 	 *	count - maximum number of skill points to allocate for that skill
 	 *	satisfy - boolean value to stop(true) or continue(false) further allocation until count is met. Defaults to true if not specified.
-     *
+	 *
 	 *	See libs/config/Templates/AutoSkillExampleBuilds.txt for Config.AutoSkill.Build examples.
 	 */
 	Config.AutoSkill.Enabled = false; // Enable or disable AutoSkill system
@@ -529,13 +529,13 @@ function LoadConfig() {
 
 	/* AutoStat builds character based on array defined by the user and this will replace AutoBuild's stat system.
 	 * AutoStat will stat Build array order. You may want to stat strength or dexterity first to meet item requirements.
-     *
+	 *
 	 * Format: Config.AutoStat.Build = [[statType, stat], [statType, stat], ... [statType, stat]];
 	 *	statType - defined as string, or as corresponding stat integer. "strength" or 0, "dexterity" or 2, "vitality" or 3, "energy" or 1
 	 *	stat - set to an integer value, and it will spend stat points until it reaches desired *hard stat value (*+stats from items are ignored).
 	 *	You can also set stat to string value "all", and it will spend all the remaining points.
 	 *	Dexterity can be set to "block" and it will stat dexterity up the the desired block value specified in arguemnt (ignored in classic).
-     *
+	 *
 	 *	See libs/config/Templates/AutoStatExampleBuilds.txt for Config.AutoStat.Build examples. 
 	 */
 	Config.AutoStat.Enabled = false; // Enable or disable AutoStat system

--- a/d2bs/kolbot/libs/config/Templates/AutoSkillExampleBuilds.txt
+++ b/d2bs/kolbot/libs/config/Templates/AutoSkillExampleBuilds.txt
@@ -1,0 +1,35 @@
+Refer to sdk/skills.txt for skill id index
+
+Example: Blizzard Sorceress
+
+Config.AutoSkill.Build  = [
+	[37, 1, true], [42, 1, true], [54, 1, true],  // spend points in warmth, static, teleport (prerequisite to teleport: telekenesis will be learned automatically)
+	[59, 1, false], [55, 7, true], [45, 13, true], // learn blizzard if possible, and move on to glacial spike, and ice blast
+												   // if satisfy boolean was defined for blizzard as [59, 1, true] and character was under level 24, AutoSkill will stop at this point
+	[59, 7, false], [65, 1, true], // get blizzard skill level up to 7 and learn cold mastery
+	[59, 20, false], [65, 20, true], // max blizzard, max cold mastery
+	[55, 20, true], [45, 20, true], // max glacial spike, max ice blast
+];
+
+
+Example: Fire Sorceress
+
+Config.AutoSkill.Build  = [
+	[36, 4, false], [40, 1, false], // learn fire bolt until skill level 4, learn frozen armor
+	[36, 8, false], [37, 1, false], [42, 1, false], // learn fire bolt until skill level 7, learn warmth, learn static field
+	[47, 6, false], [54, 1, true], // learn fire ball until skill level 7, learn teleport
+	[61, 1, false], [47, 20, false], // learn fire mastery when available, max fire ball
+	[36, 12, false], [61, 2, false], // leran fire bolt until 14 and skill extra point in fire mastery
+	[36, 14, false], [61, 5, false], // continue leveling up fire bolt and fire mastery
+	[36, 16, false], [61, 6, false], // continue leveling up fire bolt and fire mastery
+	[36, 17, false], [61, 7, false], // continue leveling up fire bolt and fire mastery
+	[36, 18, false], [61, 8, false], // continue leveling up fire bolt and fire mastery
+	[36, 19, false], [61, 9, false], // continue leveling up fire bolt and fire mastery
+	[36, 20, true], [61, 10, false], // max fire bolt and continue leveling fire mastery
+	[56, 5, true], [61, 15, false], // learn up to 5 meteor first, and fire mastery
+	[56, 7, false], [61, 16, false], // continue leveling up meteor and fire mastery
+	[56, 8, false], [61, 17, false], // continue leveling up meteor and fire mastery
+	[56, 9, false], [61, 18, false], // continue leveling up meteor and fire mastery
+	[56, 10, false], [61, 20, false], // continue leveling up meteor and  max fire mastery
+	[56, 20, false], [41, 20, false] // max meteor, max inferno
+];

--- a/d2bs/kolbot/libs/config/Templates/AutoStatExampleBuilds.txt
+++ b/d2bs/kolbot/libs/config/Templates/AutoStatExampleBuilds.txt
@@ -1,0 +1,51 @@
+You may input stat types as an integer, or as string type defined as below.
+Make sure string types are defined in lowercase.
+
+0, "strength", "str", "s"
+1, "energy", "enr", "e"
+2, "dexterity", "dex", "d"
+3, "vitality", "vit", "v"
+
+
+Example:
+
+Config.AutoStat.Build = [
+	["strength", 35], // spend points in strength until it reaches 35 strength (all +stats from items are ingnored!)
+	["vitality", 50], // spend points in vitality until it reaches 50.
+	["dexterity", "block"], // spend points in dexterity until it reaches desired block chance defined in Config.AutoStat.BlockChance (+dexterity items are taken into account for "block" option)
+							// when more stat points are available after leveling, AutoStat will go through the array again and it will continue to stat dexterity as needed.
+							// if paladin has holy shield skill available and if it's not active, it'll attemp to cast holy shield first
+	["strength", 55], // spend points on strength until it reaches 55
+	["vitality", "all"] // all remaining points will be spent in vitality.
+];
+
+
+If you are allocating stats points for high level character and you know your strength/dex requirements,
+you may simply specify strength and dexterity value to what you want and put rest into vitality
+
+Config.AutoStat.Build = [
+	["strength", 55], // spend points in strength until it reaches 35
+	["dexterity", 150], // spend points in dexterity until it reaches 150
+	["vitality", "all"] // spend all remaining points in vitality
+];
+
+
+If you are building a character from scratch along with AutoBuild system, you want to be more specific about order of stat allocation.
+
+Config.AutoStat.Build = [
+	["strength", 12], // stat strength for quilt armor
+	["vitality", 28], // spend in vitality until it reaches 28 (level 5)
+	["energy", 50], // spend in energy until 50 (level 8)
+	["vitality", 50], // spend more in vitality
+	["strength", 15], // get up to 15 strength (level 13)
+	["vitality", 65], // spend in vitality (level 18)
+	["strength", 35], // get up to 25 strength (level 20)
+	["energy", 75], // spend in energy (level 25)
+	["v", 75], // level 27
+	["s", 55], // level 31
+	["v", 100], // level 36
+	["s", 80], // level 41
+	["v", 125], // level 46
+	["s", 95], // level 49 (less if done stat quests)
+	["v", "all"], // put rest of the points in vitality
+];

--- a/d2bs/kolbot/tools/AutoBuildThread.js
+++ b/d2bs/kolbot/tools/AutoBuildThread.js
@@ -10,6 +10,8 @@
 
 js_strict(true);
 
+if (!isIncluded("common/AutoSkill.js")) { include("common/AutoSkill.js"); };
+if (!isIncluded("common/AutoStat.js")) { include("common/AutoStat.js"); };
 if (!isIncluded("common/Config.js")) { include("common/Config.js"); };
 if (!isIncluded("common/Cubing.js")) { include("common/Cubing.js"); };
 if (!isIncluded("common/Prototypes.js")) { include("common/Prototypes.js"); };
@@ -79,6 +81,10 @@ function spendStatPoints () {
 	var spentEveryPoint = true;
 	var unusedStatPoints = me.getStat(4);
 	var len = stats.length;
+
+	if (Config.AutoStat.Enabled) {
+		return spentEveryPoint;
+	}
 
 	if (len > unusedStatPoints) {
 		len = unusedStatPoints;
@@ -173,6 +179,10 @@ function spendSkillPoints () {
 	var unusedSkillPoints = me.getStat(5);
 	var len = skills.length;
 
+	if (Config.AutoSkill.Enabled) {
+		return spentEveryPoint;
+	}
+
 	if (len > unusedSkillPoints) {
 		len = unusedSkillPoints;
 		AutoBuild.print("Warning: Number of skills specified in your build template at level "+me.charlvl+" exceeds the available unused skill points"+
@@ -232,7 +242,7 @@ function main () {
 		while (true) {
 			var levels = gainedLevels();
 
-			if (levels > 0 && canSpendPoints()) {
+			if (levels > 0 && (canSpendPoints() || Config.AutoSkill.Enabled || Config.AutoStat.Enabled)) {
 				scriptBroadcast("toggleQuitlist");
 				AutoBuild.print("Level up detected (", prevLevel, "-->", me.charlvl, ")");
 				spendSkillPoints();
@@ -242,6 +252,14 @@ function main () {
 
 				if (debug) {
 					AutoBuild.print("Incrementing cached character level to", prevLevel + 1);
+				}
+
+				if (Config.AutoSkill.Enabled) {
+					AutoSkill.init(Config.AutoSkill.Build, Config.AutoSkill.Save);
+				}
+
+				if (Config.AutoStat.Enabled) {
+					AutoStat.init(Config.AutoStat.Build, Config.AutoStat.Save, Config.AutoStat.BlockChance, Config.AutoStat.UseBulk);
 				}
 
 				// prevLevel doesn't get set to me.charlvl because


### PR DESCRIPTION
-Automatically allocate skill and/or stat points based on build array that is goal oriented
-Can work in place of AutoBuild's skill/stat system that is limited to spending points only seen at each level up.
-Read description in character config and config/Templates/AutoSkillExampleBuilds.txt and config/Templates/AutoStatExampleBuilds.txt for examples