### PR TITLE
Fix MFHelper wrong area and exclude hostile players as potential leader

### DIFF
--- a/d2bs/kolbot/libs/bots/AutoBaal.js
+++ b/d2bs/kolbot/libs/bots/AutoBaal.js
@@ -136,7 +136,7 @@ function AutoBaal() {
 					solofail += 1;
 				}
 
-				if (suspect.area === destination) { // first player in our party found in destination area...
+				if (suspect.area === destination && !getPlayerFlag(me.gid, suspect.gid, 8)) { // first player not hostile found in destination area...
 					leader = suspect.name; // ... is our leader
 					print("ÿc4AutoBaal: ÿc0Autodetected " + leader);
 					return true;

--- a/d2bs/kolbot/libs/bots/MFHelper.js
+++ b/d2bs/kolbot/libs/bots/MFHelper.js
@@ -5,7 +5,7 @@
 */
 
 function MFHelper() {
-	var i, player, playerAct, split, area,
+	var i, player, playerAct, split,
 		oldCommand = "",
 		command = "";
 
@@ -183,7 +183,6 @@ MainLoop:
 					print("ÿc4MFHelperÿc0: Kill");
 
 					split = command.split("kill ")[1];
-					area = player.area;
 
 					for (i = 0; i < 5; i += 1) {
 						if (Pather.usePortal(player.area, player.name)) {
@@ -193,7 +192,7 @@ MainLoop:
 						delay(1000);
 					}
 
-					if (me.area === area) {
+					if (me.area === player.area) {
 						Precast.doPrecast(false);
 
 						try {
@@ -218,8 +217,6 @@ MainLoop:
 				} else if (command.indexOf("clearlevel") > -1) {
 					print("ÿc4MFHelperÿc0: Clear Level");
 
-					area = player.area;
-
 					for (i = 0; i < 5; i += 1) {
 						if (Pather.usePortal(player.area, player.name)) {
 							break;
@@ -228,7 +225,7 @@ MainLoop:
 						delay(1000);
 					}
 
-					if (me.area === area) {
+					if (me.area === player.area) {
 						Precast.doPrecast(false);
 						Attack.clearLevel(Config.ClearType);
 						Precast.doPrecast(true);
@@ -243,7 +240,6 @@ MainLoop:
 					print("ÿc4MFHelperÿc0: Clear");
 
 					split = command.split("clear ")[1];
-					area = player.area;
 
 					for (i = 0; i < 5; i += 1) {
 						if (Pather.usePortal(player.area, player.name)) {
@@ -253,7 +249,7 @@ MainLoop:
 						delay(1000);
 					}
 
-					if (me.area === area) {
+					if (me.area === player.area) {
 						Precast.doPrecast(false);
 
 						try {
@@ -301,8 +297,6 @@ MainLoop:
 				} else if (command.indexOf("council") > -1) {
 					print("ÿc4MFHelperÿc0: Kill Council");
 
-					area = player.area;
-
 					for (i = 0; i < 5; i += 1) {
 						if (Pather.usePortal(player.area, player.name)) {
 							break;
@@ -311,7 +305,7 @@ MainLoop:
 						delay(1000);
 					}
 
-					if (me.area === area) {
+					if (me.area === player.area) {
 						Precast.doPrecast(false);
 						Attack.clearList(Attack.getMob([345, 346, 347], 0, 40));
 

--- a/d2bs/kolbot/libs/bots/Wakka.js
+++ b/d2bs/kolbot/libs/bots/Wakka.js
@@ -27,7 +27,7 @@ function Wakka() {
 					solofail += 1;
 				}
 
-				if (suspect.area === destination) { // first player in our party found in destination area...
+				if (suspect.area === destination && !getPlayerFlag(me.gid, suspect.gid, 8)) { // first player not hostile found in destination area...
 					leader = suspect.name; // ... is our leader
 
 					if (suspect.area === 131) {


### PR DESCRIPTION
Fixed MFHelper wrong leader area when receiving command.
Fixed AutoBaal detecting hostile player as a leader.
Fixed Wakka detecting hostile player as leader.