### PR TITLE
Fix soul and doll mix up

### DIFF
--- a/d2bs/kolbot/libs/bots/BaalAssistant.js
+++ b/d2bs/kolbot/libs/bots/BaalAssistant.js
@@ -408,7 +408,7 @@ function BaalAssistant() {
 						Pather.moveTo(15095, 5029);
 
 						if ((SoulQuit && getUnit(1, 641)) || (DollQuit && getUnit(1, 691))) {
-							print("Undead soul killers or Undead stygian dolls found, ending script.");
+							print("Burning Souls or Undead Soul Killers found, ending script.");
 							return true;
 						}
 
@@ -470,8 +470,8 @@ function BaalAssistant() {
 							throw new Error("No portals to Throne.");
 						}
 
-						if ((SoulQuit && getUnit(1, 691)) || (DollQuit && getUnit(1, 690))) {
-							print("Undead soul killers or Undead stygian dolls found, ending script.");
+						if ((SoulQuit && getUnit(1, 641)) || (DollQuit && getUnit(1, 691))) {
+							print("Burning Souls or Undead Soul Killers found, ending script.");
 							return true;
 						}
 

--- a/d2bs/kolbot/libs/bots/BaalHelper.js
+++ b/d2bs/kolbot/libs/bots/BaalHelper.js
@@ -245,7 +245,7 @@ WSKLoop:
 	}
 
 	if (Config.BaalHelper.DollQuit && getUnit(1, 691)) {
-		print("Soul Killers found.");
+		print("Undead Soul Killers found.");
 
 		return true;
 	}

--- a/d2bs/kolbot/libs/common/Attacks/Paladin.js
+++ b/d2bs/kolbot/libs/common/Attacks/Paladin.js
@@ -100,7 +100,7 @@ var ClassAttack = {
 
 		switch (attackSkill) {
 		case 112:
-			if (unit.classid === 691 && Config.AvoidDolls) {
+			if (Config.AvoidDolls && [212, 213, 214, 215, 216, 690, 691].indexOf(unit.classid) > -1) {
 				this.dollAvoid(unit);
 
 				if (aura > -1) {
@@ -223,12 +223,15 @@ var ClassAttack = {
 	},
 
 	dollAvoid: function (unit) {
-		var i,
-			positions = [[10, 10], [-10, 10], [10, -10], [-10, -10]];
+		var i, cx, cy,
+			distance = 14;
 
-		for (i = 0; i < positions.length; i += 1) {
-			if (Attack.validSpot(unit.x + positions[i][0], unit.y + positions[i][1])) {
-				return Pather.moveTo(unit.x + positions[i][0], unit.y + positions[i][1]);
+		for (i = 0; i < 2 * Math.PI; i += Math.PI / 6) {
+			cx = Math.round(Math.cos(i) * distance);
+			cy = Math.round(Math.sin(i) * distance);
+
+			if (Attack.validSpot(unit.x + cx, unit.y + cy)) {
+				return Pather.moveTo(unit.x + cx, unit.y + cy);
 			}
 		}
 

--- a/d2bs/kolbot/libs/config/Amazon.js
+++ b/d2bs/kolbot/libs/config/Amazon.js
@@ -116,8 +116,8 @@ function LoadConfig() {
 		Config.Baal.HotTPMessage = "Hot TP!";
 		Config.Baal.SafeTPMessage = "Safe TP!";
 		Config.Baal.BaalMessage = "Baal!";
-		Config.Baal.SoulQuit = false; // End script if Souls (Undead Soul Killers) are found.
-		Config.Baal.DollQuit = false; // End script if Dolls (Undead Stigyan Dolls) are found.
+		Config.Baal.SoulQuit = false; // End script if Souls (Burning Souls) are found.
+		Config.Baal.DollQuit = false; // End script if Dolls (Undead Soul Killers) are found.
 		Config.Baal.KillBaal = true; // Kill Baal. Leaves game after wave 5 if false.
 
 	/* ### leeching section ###

--- a/d2bs/kolbot/libs/config/Assassin.js
+++ b/d2bs/kolbot/libs/config/Assassin.js
@@ -116,8 +116,8 @@ function LoadConfig() {
 		Config.Baal.HotTPMessage = "Hot TP!";
 		Config.Baal.SafeTPMessage = "Safe TP!";
 		Config.Baal.BaalMessage = "Baal!";
-		Config.Baal.SoulQuit = false; // End script if Souls (Undead Soul Killers) are found.
-		Config.Baal.DollQuit = false; // End script if Dolls (Undead Stigyan Dolls) are found.
+		Config.Baal.SoulQuit = false; // End script if Souls (Burning Souls) are found.
+		Config.Baal.DollQuit = false; // End script if Dolls (Undead Soul Killers) are found.
 		Config.Baal.KillBaal = true; // Kill Baal. Leaves game after wave 5 if false.
 
 	/* ### leeching section ###

--- a/d2bs/kolbot/libs/config/Barbarian.js
+++ b/d2bs/kolbot/libs/config/Barbarian.js
@@ -116,8 +116,8 @@ function LoadConfig() {
 		Config.Baal.HotTPMessage = "Hot TP!";
 		Config.Baal.SafeTPMessage = "Safe TP!";
 		Config.Baal.BaalMessage = "Baal!";
-		Config.Baal.SoulQuit = false; // End script if Souls (Undead Soul Killers) are found.
-		Config.Baal.DollQuit = false; // End script if Dolls (Undead Stigyan Dolls) are found.
+		Config.Baal.SoulQuit = false; // End script if Souls (Burning Souls) are found.
+		Config.Baal.DollQuit = false; // End script if Dolls (Undead Soul Killers) are found.
 		Config.Baal.KillBaal = true; // Kill Baal. Leaves game after wave 5 if false.
 
 	/* ### leeching section ###

--- a/d2bs/kolbot/libs/config/Druid.js
+++ b/d2bs/kolbot/libs/config/Druid.js
@@ -116,8 +116,8 @@ function LoadConfig() {
 		Config.Baal.HotTPMessage = "Hot TP!";
 		Config.Baal.SafeTPMessage = "Safe TP!";
 		Config.Baal.BaalMessage = "Baal!";
-		Config.Baal.SoulQuit = false; // End script if Souls (Undead Soul Killers) are found.
-		Config.Baal.DollQuit = false; // End script if Dolls (Undead Stigyan Dolls) are found.
+		Config.Baal.SoulQuit = false; // End script if Souls (Burning Souls) are found.
+		Config.Baal.DollQuit = false; // End script if Dolls (Undead Soul Killers) are found.
 		Config.Baal.KillBaal = true; // Kill Baal. Leaves game after wave 5 if false.
 
 	/* ### leeching section ###

--- a/d2bs/kolbot/libs/config/Necromancer.js
+++ b/d2bs/kolbot/libs/config/Necromancer.js
@@ -116,8 +116,8 @@ function LoadConfig() {
 		Config.Baal.HotTPMessage = "Hot TP!";
 		Config.Baal.SafeTPMessage = "Safe TP!";
 		Config.Baal.BaalMessage = "Baal!";
-		Config.Baal.SoulQuit = false; // End script if Souls (Undead Soul Killers) are found.
-		Config.Baal.DollQuit = false; // End script if Dolls (Undead Stigyan Dolls) are found.
+		Config.Baal.SoulQuit = false; // End script if Souls (Burning Souls) are found.
+		Config.Baal.DollQuit = false; // End script if Dolls (Undead Soul Killers) are found.
 		Config.Baal.KillBaal = true; // Kill Baal. Leaves game after wave 5 if false.
 
 	/* ### leeching section ###

--- a/d2bs/kolbot/libs/config/Paladin.js
+++ b/d2bs/kolbot/libs/config/Paladin.js
@@ -116,8 +116,8 @@ function LoadConfig() {
 		Config.Baal.HotTPMessage = "Hot TP!";
 		Config.Baal.SafeTPMessage = "Safe TP!";
 		Config.Baal.BaalMessage = "Baal!";
-		Config.Baal.SoulQuit = false; // End script if Souls (Undead Soul Killers) are found.
-		Config.Baal.DollQuit = false; // End script if Dolls (Undead Stigyan Dolls) are found.
+		Config.Baal.SoulQuit = false; // End script if Souls (Burning Souls) are found.
+		Config.Baal.DollQuit = false; // End script if Dolls (Undead Soul Killers) are found.
 		Config.Baal.KillBaal = true; // Kill Baal. Leaves game after wave 5 if false.
 
 	/* ### leeching section ###
@@ -510,7 +510,7 @@ function LoadConfig() {
 	Config.Wereform = false; // 0 / false - don't shapeshift, 1 / "Werewolf" - change to werewolf, 2 / "Werebear" - change to werebear
 
 	// Class specific config
-	Config.AvoidDolls = false; // Try to attack Soul Killers from a greater distance with hammerdins.
+	Config.AvoidDolls = false; // Try to attack dolls from a greater distance with hammerdins.
 	Config.Vigor = true; // Swith to Vigor when running
 	Config.Charge = true; // Use Charge when running
 	Config.Redemption = [50, 50]; // Switch to Redemption after clearing an area if under designated life or mana. Format: [lifepercent, manapercent]

--- a/d2bs/kolbot/libs/config/Sorceress.js
+++ b/d2bs/kolbot/libs/config/Sorceress.js
@@ -116,8 +116,8 @@ function LoadConfig() {
 		Config.Baal.HotTPMessage = "Hot TP!";
 		Config.Baal.SafeTPMessage = "Safe TP!";
 		Config.Baal.BaalMessage = "Baal!";
-		Config.Baal.SoulQuit = false; // End script if Souls (Undead Soul Killers) are found.
-		Config.Baal.DollQuit = false; // End script if Dolls (Undead Stigyan Dolls) are found.
+		Config.Baal.SoulQuit = false; // End script if Souls (Burning Souls) are found.
+		Config.Baal.DollQuit = false; // End script if Dolls (Undead Soul Killers) are found.
 		Config.Baal.KillBaal = true; // Kill Baal. Leaves game after wave 5 if false.
 
 	/* ### leeching section ###


### PR DESCRIPTION
Baal.js, BaalAssistant.js, BaalHelper.js, Character Configs
-Fix soul and doll mix up

Attack/Paladin.js
-Add more doll classids for Config.AvoidDolls and add more positions to check.