### PR TITLE
add pickItems before quit

### DIFF
--- a/d2bs/kolbot/tools/ToolsThread.js
+++ b/d2bs/kolbot/tools/ToolsThread.js
@@ -649,6 +649,7 @@ function main() {
 			}
 
 			this.checkPing(false); // In case of quitlist triggering first
+			Pickit.pickItems();
 			this.exit();
 
 			break;


### PR DESCRIPTION
Give Followers the chance to pick items on the last boss sequence.

Fixes: https://github.com/kolton/d2bot-with-kolbot/issues/835