### PR TITLE
Pathing improvements for walking bots

### DIFF
--- a/d2bs/kolbot/libs/bots/AncientTunnels.js
+++ b/d2bs/kolbot/libs/bots/AncientTunnels.js
@@ -9,7 +9,9 @@ function AncientTunnels() {
 	Pather.useWaypoint(44);
 	Precast.doPrecast(true);
 
-	if (Config.AncientTunnels.OpenChest && Pather.moveToPreset(me.area, 2, 580) && Misc.openChests(5)) {
+	if (Config.AncientTunnels.OpenChest && Pather.moveToPreset(me.area, 2, 580)) {
+		Chest.scan(5);
+		Chest.openChests();
 		Pickit.pickItems();
 	}
 

--- a/d2bs/kolbot/libs/bots/Andariel.js
+++ b/d2bs/kolbot/libs/bots/Andariel.js
@@ -26,7 +26,7 @@ function Andariel() {
 			}
 
 			if (getDistance(me, target) <= 10) {
-				Pather.moveTo(me.x > 22548 ? 22535 : 22560, 9520);
+				Pather.pathTo(me.x > 22548 ? 22535 : 22560, 9520);
 			}
 		}
 
@@ -41,7 +41,7 @@ function Andariel() {
 		throw new Error("Failed to move to Catacombs Level 4");
 	}
 
-	Pather.moveTo(22549, 9520);
+	Pather.pathTo(22549, 9520);
 
 	if (me.classid === 1 && me.gametype === 0) {
 		this.killAndariel();

--- a/d2bs/kolbot/libs/bots/AutoBaal.js
+++ b/d2bs/kolbot/libs/bots/AutoBaal.js
@@ -212,7 +212,7 @@ function AutoBaal() {
 			if (throneCheck && me.area === 109) { // wait for throne signal - leader's safe message
 				print("ÿc4AutoBaal: ÿc0Trying to take TP to throne.");
 				Pather.usePortal(131, null); // take TP to throne
-				Pather.moveTo(Config.AutoBaal.LeechSpot[0], Config.AutoBaal.LeechSpot[1]); // move to a safe spot
+				Pather.pathTo(Config.AutoBaal.LeechSpot[0], Config.AutoBaal.LeechSpot[1]); // move to a safe spot
 				Precast.doPrecast(true);
 				Town.getCorpse(); // check for corpse - happens if you die and reenter
 			}
@@ -222,7 +222,7 @@ function AutoBaal() {
 			}
 
 			if (baalCheck && me.area === 131) { // wait for baal signal - leader's baal message
-				Pather.moveTo(15092, 5010); // move closer to chamber portal
+				Pather.pathTo(15092, 5010); // move closer to chamber portal
 				Precast.doPrecast(false);
 
 				while (getUnit(1, 543)) { // wait for baal to go through the portal
@@ -235,7 +235,7 @@ function AutoBaal() {
 				print("ÿc4AutoBaal: ÿc0Entering chamber.");
 
 				if (Pather.usePortal(null, null, portal)) { // enter chamber
-					Pather.moveTo(15166, 5903); // go to a safe position
+					Pather.pathTo(15166, 5903); // go to a safe position
 				}
 
 				Town.getCorpse(); // check for corpse - happens if you die and reenter

--- a/d2bs/kolbot/libs/bots/Baal.js
+++ b/d2bs/kolbot/libs/bots/Baal.js
@@ -119,7 +119,7 @@ function Baal() {
 		}
 
 		for (i = 0; i < pos.length; i += 2) {
-			Pather.moveTo(pos[i], pos[i + 1]);
+			Pather.pathTo(pos[i], pos[i + 1]);
 			Attack.clear(25);
 		}
 	};
@@ -129,7 +129,7 @@ function Baal() {
 		if (hydra) {
 			do {
 				if (hydra.mode !== 12 && hydra.getStat(172) !== 2) {
-					Pather.moveTo(15072, 5002);
+					Pather.pathTo(15072, 5002);
 					while (hydra.mode !== 12) {
 						delay(500);
 						if (!copyUnit(hydra).x) {
@@ -208,7 +208,7 @@ function Baal() {
 		throw new Error("Failed to move to Throne of Destruction.");
 	}
 
-	Pather.moveTo(15095, 5029);
+	Pather.pathTo(15095, 5029);
 
 	if (Config.Baal.DollQuit && getUnit(1, 691)) {
 		say("Dolls found! NG.");
@@ -224,7 +224,7 @@ function Baal() {
 
 	if (Config.PublicMode) {
 		this.announce();
-		Pather.moveTo(15118, 5002);
+		Pather.pathTo(15118, 5002);
 		Pather.makePortal();
 		say(Config.Baal.HotTPMessage);
 		Attack.clear(15);
@@ -233,7 +233,7 @@ function Baal() {
 	this.clearThrone();
 
 	if (Config.PublicMode) {
-		Pather.moveTo(15118, 5045);
+		Pather.pathTo(15118, 5045);
 		Pather.makePortal();
 		say(Config.Baal.SafeTPMessage);
 		Precast.doPrecast(true);
@@ -241,12 +241,12 @@ function Baal() {
 
 	tick = getTickCount();
 
-	Pather.moveTo(15094, me.classid === 3 ? 5029 : 5038);
+	Pather.pathTo(15094, me.classid === 3 ? 5029 : 5038);
 
 MainLoop:
 	while (true) {
 		if (getDistance(me, 15094, me.classid === 3 ? 5029 : 5038) > 3) {
-			Pather.moveTo(15094, me.classid === 3 ? 5029 : 5038);
+			Pather.pathTo(15094, me.classid === 3 ? 5029 : 5038);
 		}
 
 		if (!getUnit(1, 543)) {
@@ -309,7 +309,7 @@ MainLoop:
 			say(Config.Baal.BaalMessage);
 		}
 
-		Pather.moveTo(15090, 5008);
+		Pather.pathTo(15090, 5008);
 		delay(5000);
 		Precast.doPrecast(true);
 
@@ -325,7 +325,7 @@ MainLoop:
 			throw new Error("Couldn't find portal.");
 		}
 
-		Pather.moveTo(15134, 5923);
+		Pather.pathTo(15134, 5923);
 		Attack.kill(544); // Baal
 		Pickit.pickItems();
 	}

--- a/d2bs/kolbot/libs/bots/BaalAssistant.js
+++ b/d2bs/kolbot/libs/bots/BaalAssistant.js
@@ -141,7 +141,7 @@ function BaalAssistant() {
 					return false;
 				}
 				if (getDistance(me, 15094, 5029) > 3) {
-					Pather.moveTo(15094, 5029);
+					Pather.pathTo(15094, 5029);
 				}
 				if (Config.AttackSkill[4] > 0) {
 					Skill.setSkill(Config.AttackSkill[4], 0);
@@ -225,7 +225,7 @@ function BaalAssistant() {
 			}
 		}
 		for (i = 0; i < pos.length; i += 2) {
-			Pather.moveTo(pos[i], pos[i + 1]);
+			Pather.pathTo(pos[i], pos[i + 1]);
 			Attack.clear(25);
 		}
 	};
@@ -235,7 +235,7 @@ function BaalAssistant() {
 		if (hydra) {
 			do {
 				if (hydra.mode !== 12 && hydra.getStat(172) !== 2) {
-					Pather.moveTo(15072, 5002);
+					Pather.pathTo(15072, 5002);
 					while (hydra.mode !== 12) {
 						delay(500);
 						if (!copyUnit(hydra).x) {
@@ -398,26 +398,26 @@ function BaalAssistant() {
 						}
 
 						if (entrance) {
-							Pather.moveTo(entrance.x > me.x ? entrance.x - 5 : entrance.x + 5, entrance.y > me.y ? entrance.y - 5 : entrance.y + 5);
+							Pather.pathTo(entrance.x > me.x ? entrance.x - 5 : entrance.x + 5, entrance.y > me.y ? entrance.y - 5 : entrance.y + 5);
 						}
 
-						if (!Pather.moveToExit(131, true) || !Pather.moveTo(15118, 5002)) {
+						if (!Pather.moveToExit(131, true) || !Pather.pathTo(15118, 5002)) {
 							throw new Error("Failed to move to Throne of Destruction.");
 						}
 
-						Pather.moveTo(15095, 5029);
+						Pather.pathTo(15095, 5029);
 
 						if ((SoulQuit && getUnit(1, 641)) || (DollQuit && getUnit(1, 691))) {
 							print("Burning Souls or Undead Soul Killers found, ending script.");
 							return true;
 						}
 
-						Pather.moveTo(15118, 5002);
+						Pather.pathTo(15118, 5002);
 						if (Helper) {
 							Attack.clear(15);
-							Pather.moveTo(15118, 5002);
+							Pather.pathTo(15118, 5002);
 						} else {
-							Pather.moveTo(15117, 5045);
+							Pather.pathTo(15117, 5045);
 						}
 
 						secondAttempt = true;
@@ -431,9 +431,9 @@ function BaalAssistant() {
 							}
 							if (Helper) {
 								Attack.clear(15);
-								Pather.moveTo(15118, 5002);
+								Pather.pathTo(15118, 5002);
 							} else {
-								Pather.moveTo(15117, 5045);
+								Pather.pathTo(15117, 5045);
 							}
 						}
 					}
@@ -477,9 +477,9 @@ function BaalAssistant() {
 
 						if (Helper) {
 							Attack.clear(15);
-							Pather.moveTo(15118, 5002);
+							Pather.pathTo(15118, 5002);
 						} else {
-							Pather.moveTo(15117, 5045);
+							Pather.pathTo(15117, 5045);
 						}
 
 						secondAttempt = true;
@@ -493,9 +493,9 @@ function BaalAssistant() {
 							}
 							if (Helper) {
 								Attack.clear(15);
-								Pather.moveTo(15118, 5002);
+								Pather.pathTo(15118, 5002);
 							} else {
-								Pather.moveTo(15117, 5045);
+								Pather.pathTo(15117, 5045);
 							}
 						}
 					}
@@ -515,7 +515,7 @@ function BaalAssistant() {
 						Attack.clear(15);
 						this.clearThrone();
 
-						Pather.moveTo(15094, me.classid === 3 ? 5029 : 5038);
+						Pather.pathTo(15094, me.classid === 3 ? 5029 : 5038);
 						Precast.doPrecast(true);
 					}
 
@@ -524,7 +524,7 @@ function BaalAssistant() {
 					MainLoop: while (true) {
 						if (Helper) {
 							if (getDistance(me, 15094, me.classid === 3 ? 5029 : 5038) > 3) {
-								Pather.moveTo(15094, me.classid === 3 ? 5029 : 5038);
+								Pather.pathTo(15094, me.classid === 3 ? 5029 : 5038);
 							}
 						}
 
@@ -607,11 +607,11 @@ function BaalAssistant() {
 
 			if ((throneStatus || baalCheck) && KillBaal && me.area === 131) {
 				if (Helper) {
-					Pather.moveTo(15090, 5008);
+					Pather.pathTo(15090, 5008);
 					delay(2000);
 					Precast.doPrecast(true);
 				} else {
-					Pather.moveTo(15090, 5010);
+					Pather.pathTo(15090, 5010);
 					Precast.doPrecast(true);
 				}
 
@@ -638,7 +638,7 @@ function BaalAssistant() {
 
 				if (Helper) {
 					delay(1000);
-					Pather.moveTo(15134, 5923);
+					Pather.pathTo(15134, 5923);
 					baal = getUnit(1, 544);
 					Attack.kill(544);
 					Pickit.pickItems();
@@ -649,7 +649,7 @@ function BaalAssistant() {
 						return true;
 					}
 				} else {
-					Pather.moveTo(15177, 5952);
+					Pather.pathTo(15177, 5952);
 					baal = getUnit(1, 544);
 					while (baal) {
 						delay(1000);

--- a/d2bs/kolbot/libs/bots/BaalHelper.js
+++ b/d2bs/kolbot/libs/bots/BaalHelper.js
@@ -117,7 +117,7 @@ function BaalHelper() { // experi-mental
 		}
 
 		for (i = 0; i < pos.length; i += 2) {
-			Pather.moveTo(pos[i], pos[i + 1]);
+			Pather.pathTo(pos[i], pos[i + 1]);
 			Attack.clear(30);
 		}
 	};
@@ -128,7 +128,7 @@ function BaalHelper() { // experi-mental
 		if (hydra) {
 			do {
 				if (hydra.mode !== 12 && hydra.getStat(172) !== 2) {
-					Pather.moveTo(15118, 5002);
+					Pather.pathTo(15118, 5002);
 
 					while (hydra.mode !== 12) {
 						delay(500);
@@ -213,7 +213,7 @@ WSKLoop:
 		}
 
 		if (entrance) {
-			Pather.moveTo(entrance.x > me.x ? entrance.x - 5 : entrance.x + 5, entrance.y > me.y ? entrance.y - 5 : entrance.y + 5);
+			Pather.pathTo(entrance.x > me.x ? entrance.x - 5 : entrance.x + 5, entrance.y > me.y ? entrance.y - 5 : entrance.y + 5);
 		}
 
 		if (!Pather.moveToExit([130, 131], false)) {
@@ -224,7 +224,7 @@ WSKLoop:
 			throw new Error("Failed to move to Throne of Destruction.");
 		}
 
-		if (!Pather.moveTo(15113, 5040)) {
+		if (!Pather.pathTo(15113, 5040)) {
 			D2Bot.printToConsole("path fail");
 		}
 	} else {
@@ -256,12 +256,12 @@ WSKLoop:
 
 	tick = getTickCount();
 
-	Pather.moveTo(15093, me.classid === 3 ? 5029 : 5039);
+	Pather.pathTo(15093, me.classid === 3 ? 5029 : 5039);
 
 MainLoop:
 	while (true) {
 		if (getDistance(me, 15093, me.classid === 3 ? 5029 : 5039) > 3) {
-			Pather.moveTo(15093, me.classid === 3 ? 5029 : 5039);
+			Pather.pathTo(15093, me.classid === 3 ? 5029 : 5039);
 		}
 
 		if (!getUnit(1, 543)) {
@@ -321,7 +321,7 @@ MainLoop:
 	}
 
 	if (Config.BaalHelper.KillBaal) {
-		Pather.moveTo(15092, 5011);
+		Pather.pathTo(15092, 5011);
 		Precast.doPrecast(false);
 
 		while (getUnit(1, 543)) {
@@ -329,7 +329,7 @@ MainLoop:
 		}
 
 		delay(1000);
-		Pather.moveTo(15092, 5011);
+		Pather.pathTo(15092, 5011);
 
 		portal = getUnit(2, 563);
 
@@ -339,7 +339,7 @@ MainLoop:
 			throw new Error("Couldn't find portal.");
 		}
 
-		Pather.moveTo(15134, 5923);
+		Pather.pathTo(15134, 5923);
 		Attack.kill(544); // Baal
 		Pickit.pickItems();
 	} else {

--- a/d2bs/kolbot/libs/bots/BattleOrders.js
+++ b/d2bs/kolbot/libs/bots/BattleOrders.js
@@ -40,7 +40,7 @@ function BattleOrders() {
 		quit();
 	}
 
-	Pather.moveTo(me.x + 6, me.y + 6);
+	Pather.pathTo(me.x + 6, me.y + 6);
 
 	var i,
 		tick = getTickCount(),

--- a/d2bs/kolbot/libs/bots/BoneAsh.js
+++ b/d2bs/kolbot/libs/bots/BoneAsh.js
@@ -9,7 +9,7 @@ function BoneAsh() {
 	Pather.useWaypoint(32);
 	Precast.doPrecast(true);
 
-	if (!Pather.moveTo(20047, 4898)) {
+	if (!Pather.pathTo(20047, 4898)) {
 		throw new Error("Failed to move to Bone Ash");
 	}
 

--- a/d2bs/kolbot/libs/bots/ChestMania.js
+++ b/d2bs/kolbot/libs/bots/ChestMania.js
@@ -14,7 +14,7 @@ function ChestMania() {
 			for (i = 0; i < Config.ChestMania[prop].length; i += 1) {
 				Pather.journeyTo(Config.ChestMania[prop][i]);
 				Precast.doPrecast(i == 0 ? true : false);
-				Misc.openChestsInArea(Config.ChestMania[prop][i]);
+				Chest.openChestsInArea(Config.ChestMania[prop][i]);
 			}
 
 			Town.doChores();

--- a/d2bs/kolbot/libs/bots/ClassicChaosAssistant.js
+++ b/d2bs/kolbot/libs/bots/ClassicChaosAssistant.js
@@ -104,9 +104,9 @@ function Idle() {
 			switch (me.area) {
 				case 108:
 					if (this.infLayout === 1) {
-						Pather.moveTo(7893, 5306);
+						Pather.pathTo(7893, 5306);
 					} else {
-						Pather.moveTo(7929, 5294);
+						Pather.pathTo(7929, 5294);
 					}
 					Pather.makePortal();
 					say("Infector of Souls TP Up!");
@@ -119,9 +119,9 @@ function Idle() {
 			switch (me.area) {
 				case 108:
 					if (this.seisLayout === 1) {
-						Pather.moveTo(7773, 5191);
+						Pather.pathTo(7773, 5191);
 					} else {
-						Pather.moveTo(7794, 5189);
+						Pather.pathTo(7794, 5189);
 					}
 					Pather.makePortal();
 					say("Lord De Seis TP Up!");
@@ -134,9 +134,9 @@ function Idle() {
 			switch (me.area) {
 				case 108:
 					if (this.vizLayout === 1) {
-						Pather.moveTo(7681, 5302);
+						Pather.pathTo(7681, 5302);
 					} else {
-						Pather.moveTo(7675, 5305);
+						Pather.pathTo(7675, 5305);
 					}
 					Pather.makePortal();
 					say("Grand Vizier of Chaos TP Up!");
@@ -152,9 +152,9 @@ function Idle() {
 					this.openSeal(392)
 					say("Infector of Souls spawned!");
 					if (this.infLayout === 1) {
-						Pather.moveTo(7893, 5306);
+						Pather.pathTo(7893, 5306);
 					} else {
-						Pather.moveTo(7929, 5294);
+						Pather.pathTo(7929, 5294);
 					}
 					break;
 			}
@@ -167,9 +167,9 @@ function Idle() {
 					this.openSeal(394)
 					say("Lord De Seis spawned!");
 					if (this.seisLayout === 1) {
-						Pather.moveTo(7773, 5191);
+						Pather.pathTo(7773, 5191);
 					} else {
-						Pather.moveTo(7794, 5189);
+						Pather.pathTo(7794, 5189);
 					}
 					break;
 			}
@@ -182,9 +182,9 @@ function Idle() {
 					this.openSeal(396)
 					say("Grand Vizier of Chaos spawned!");
 					if (this.vizLayout === 1) {
-						Pather.moveTo(7681, 5302);
+						Pather.pathTo(7681, 5302);
 					} else {
-						Pather.moveTo(7675, 5305);
+						Pather.pathTo(7675, 5305);
 					}
 					break;
 			}

--- a/d2bs/kolbot/libs/bots/Countess.js
+++ b/d2bs/kolbot/libs/bots/Countess.js
@@ -23,17 +23,17 @@ function Countess() {
 
 	switch (poi.roomx * 5 + poi.x) {
 	case 12565:
-		Pather.moveTo(12578, 11043);
+		Pather.pathTo(12578, 11043);
 		break;
 	case 12526:
-		Pather.moveTo(12548, 11083);
+		Pather.pathTo(12548, 11083);
 		break;
 	}
 
 	Attack.clear(20, 0, getLocaleString(2875)); // The Countess
 
 	if (Config.OpenChests) {
-		Misc.openChestsInArea();
+		Chest.openChestsInArea();
 	}
 
 	return true;

--- a/d2bs/kolbot/libs/bots/Cows.js
+++ b/d2bs/kolbot/libs/bots/Cows.js
@@ -67,7 +67,7 @@ function Cows() {
 			result = Pather.getNearestWalkable(room[0], room[1], 10, 2);
 
 			if (result) {
-				Pather.moveTo(result[0], result[1], 3);
+				Pather.pathTo(result[0], result[1], 3);
 
 				if (!Attack.clear(30)) {
 					return false;
@@ -105,7 +105,7 @@ function Cows() {
 			throw new Error("Tristram portal not found");
 		}
 
-		Pather.moveTo(25048, 5177);
+		Pather.pathTo(25048, 5177);
 
 		wirt = getUnit(2, 268);
 

--- a/d2bs/kolbot/libs/bots/Crafting.js
+++ b/d2bs/kolbot/libs/bots/Crafting.js
@@ -350,7 +350,7 @@ function shopStuff(npcId, classids, amount) {
 		path = this.processPath(npc, path);
 
 		for (i = 0; i < path.length; i += 2) {
-			Pather.moveTo(path[i] - 3, path[i + 1] - 3);
+			Pather.pathTo(path[i] - 3, path[i + 1] - 3);
 			moveNPC(npc, path[i], path[i + 1]);
 
 			for (j = 0; j < leadTimeout; j += 1) {

--- a/d2bs/kolbot/libs/bots/Diablo.js
+++ b/d2bs/kolbot/libs/bots/Diablo.js
@@ -117,9 +117,9 @@ function Diablo() {
 
 			if (!seal.mode) {
 				if (classid === 394 && Attack.validSpot(seal.x + 15, seal.y)) { // de seis optimization
-					Pather.moveTo(seal.x + 15, seal.y);
+					Pather.pathTo(seal.x + 15, seal.y);
 				} else {
-					Pather.moveTo(seal.x - 5, seal.y - 5);
+					Pather.pathTo(seal.x - 5, seal.y - 5);
 				}
 
 				delay(500);
@@ -152,7 +152,7 @@ function Diablo() {
 
 			for (i = 0; i < positions.length; i += 1) {
 				if (Attack.validSpot(target.x + positions[i][0], target.y + positions[i][1])) { // check if we can move there
-					Pather.moveTo(target.x + positions[i][0], target.y + positions[i][1]);
+					Pather.pathTo(target.x + positions[i][0], target.y + positions[i][1]);
 					Skill.setSkill(Config.AttackSkill[2], 0);
 
 					for (n = 0; n < amount; n += 1) {
@@ -201,9 +201,9 @@ function Diablo() {
 		}
 
 		if (this.vizLayout === 1) {
-			Pather.moveTo(7691, 5292);
+			Pather.pathTo(7691, 5292);
 		} else {
-			Pather.moveTo(7695, 5316);
+			Pather.pathTo(7695, 5316);
 		}
 
 		if (!this.getBoss(getLocaleString(2851))) {
@@ -222,9 +222,9 @@ function Diablo() {
 		}
 
 		if (this.seisLayout === 1) {
-			Pather.moveTo(7771, 5196);
+			Pather.pathTo(7771, 5196);
 		} else {
-			Pather.moveTo(7798, 5186);
+			Pather.pathTo(7798, 5186);
 		}
 
 		if (!this.getBoss(getLocaleString(2852))) {
@@ -245,7 +245,7 @@ function Diablo() {
 		if (this.infLayout === 1) {
 			delay(1);
 		} else {
-			Pather.moveTo(7928, 5295); // temp
+			Pather.pathTo(7928, 5295); // temp
 		}
 
 		if (!this.getBoss(getLocaleString(2853))) {
@@ -334,7 +334,7 @@ function Diablo() {
 				this.clearStrays();
 			}
 
-			Pather.moveTo(path[i], path[i + 1], 3, getDistance(me, path[i], path[i + 1]) > 50);
+			Pather.pathTo(path[i], path[i + 1], 3, getDistance(me, path[i], path[i + 1]) > 50);
 			Attack.clear(30, 0, false, this.sort);
 
 			// Push cleared positions so they can be checked for strays
@@ -374,7 +374,7 @@ function Diablo() {
 		}
 
 		if (getDistance(me, oldPos.x, oldPos.y) > 5) {
-			Pather.moveTo(oldPos.x, oldPos.y);
+			Pather.pathTo(oldPos.x, oldPos.y);
 		}
 
 		return true;
@@ -404,7 +404,7 @@ function Diablo() {
 		}
 
 		if (getDistance(me, oldPos.x, oldPos.y) > 5) {
-			Pather.moveTo(oldPos.x, oldPos.y);
+			Pather.pathTo(oldPos.x, oldPos.y);
 		}
 
 		return true;
@@ -431,7 +431,7 @@ function Diablo() {
 		Pather.useWaypoint(107);
 	}
 
-	if (!Pather.moveTo(7790, 5544)) {
+	if (!Pather.pathTo(7790, 5544)) {
 		throw new Error("Failed to move to Chaos Sanctuary");
 	}
 
@@ -439,7 +439,7 @@ function Diablo() {
 
 	if (Config.Diablo.Entrance) {
 		Attack.clear(30, 0, false, this.sort);
-		Pather.moveTo(7790, 5544);
+		Pather.pathTo(7790, 5544);
 
 		if (Config.PublicMode) {
 			Pather.makePortal();
@@ -447,16 +447,16 @@ function Diablo() {
 			Pather.teleport = !Config.Diablo.WalkClear && Pather._teleport;
 		}
 
-		Pather.moveTo(7790, 5544);
+		Pather.pathTo(7790, 5544);
 		Precast.doPrecast(true);
 		Attack.clear(30, 0, false, this.sort);
 		this.followPath(this.entranceToStar);
 	} else {
-		Pather.moveTo(7774, 5305);
+		Pather.pathTo(7774, 5305);
 		Attack.clear(15, 0, false, this.sort);
 	}
 
-	Pather.moveTo(7791, 5293);
+	Pather.pathTo(7791, 5293);
 
 	if (Config.PublicMode) {
 		Pather.makePortal();
@@ -472,11 +472,11 @@ function Diablo() {
 
 	switch (me.classid) {
 	case 1:
-		Pather.moveTo(7792, 5294);
+		Pather.pathTo(7792, 5294);
 
 		break;
 	default:
-		Pather.moveTo(7788, 5292);
+		Pather.pathTo(7788, 5292);
 
 		break;
 	}

--- a/d2bs/kolbot/libs/bots/DiabloHelper.js
+++ b/d2bs/kolbot/libs/bots/DiabloHelper.js
@@ -104,9 +104,9 @@ function DiabloHelper() {
 		this.followPath(this.vizLayout === 1 ? this.starToVizA : this.starToVizB, this.sort);
 
 		if (this.vizLayout === 1) {
-			Pather.moveTo(7691, 5292);
+			Pather.pathTo(7691, 5292);
 		} else {
-			Pather.moveTo(7695, 5316);
+			Pather.pathTo(7695, 5316);
 		}
 
 		if (!this.getBoss(getLocaleString(2851))) {
@@ -124,9 +124,9 @@ function DiabloHelper() {
 		this.followPath(this.seisLayout === 1 ? this.starToSeisA : this.starToSeisB, this.sort);
 
 		if (this.seisLayout === 1) {
-			Pather.moveTo(7771, 5196);
+			Pather.pathTo(7771, 5196);
 		} else {
-			Pather.moveTo(7798, 5186);
+			Pather.pathTo(7798, 5186);
 		}
 
 		if (!this.getBoss(getLocaleString(2852))) {
@@ -146,7 +146,7 @@ function DiabloHelper() {
 		if (this.infLayout === 1) {
 			delay(1);
 		} else {
-			Pather.moveTo(7928, 5295); // temp
+			Pather.pathTo(7928, 5295); // temp
 		}
 
 		if (!this.getBoss(getLocaleString(2853))) {
@@ -298,7 +298,7 @@ function DiabloHelper() {
 				this.clearStrays();
 			}
 
-			Pather.moveTo(path[i], path[i + 1], 3, getDistance(me, path[i], path[i + 1]) > 50);
+			Pather.pathTo(path[i], path[i + 1], 3, getDistance(me, path[i], path[i + 1]) > 50);
 			Attack.clear(30, 0, false, this.sort);
 
 			// Push cleared positions so they can be checked for strays
@@ -338,7 +338,7 @@ function DiabloHelper() {
 		}
 
 		if (getDistance(me, oldPos.x, oldPos.y) > 5) {
-			Pather.moveTo(oldPos.x, oldPos.y);
+			Pather.pathTo(oldPos.x, oldPos.y);
 		}
 
 		return true;
@@ -401,12 +401,12 @@ AreaInfoLoop:
 			Pather.useWaypoint(107);
 		}
 
-		if (!Pather.moveTo(7790, 5544)) {
+		if (!Pather.pathTo(7790, 5544)) {
 			throw new Error("Failed to move to Chaos Sanctuary");
 		}
 
 		if (!Config.DiabloHelper.Entrance) {
-			Pather.moveTo(7774, 5305);
+			Pather.pathTo(7774, 5305);
 		}
 
 CSLoop:
@@ -451,11 +451,11 @@ CSLoop:
 		Attack.clear(35, 0, false, this.sort);
 		this.followPath(this.entranceToStar);
 	} else {
-		Pather.moveTo(7774, 5305);
+		Pather.pathTo(7774, 5305);
 		Attack.clear(35, 0, false, this.sort);
 	}
 
-	Pather.moveTo(7774, 5305);
+	Pather.pathTo(7774, 5305);
 	Attack.clear(35, 0, false, this.sort);
 	this.vizierSeal();
 	this.seisSeal();
@@ -464,11 +464,11 @@ CSLoop:
 
 	switch (me.classid) {
 	case 1:
-		Pather.moveTo(7793, 5291);
+		Pather.pathTo(7793, 5291);
 
 		break;
 	default:
-		Pather.moveTo(7788, 5292);
+		Pather.pathTo(7788, 5292);
 
 		break;
 	}

--- a/d2bs/kolbot/libs/bots/Duriel.js
+++ b/d2bs/kolbot/libs/bots/Duriel.js
@@ -35,7 +35,7 @@ function Duriel() {
 			}
 
 			if (getDistance(me, target) <= 10) {
-				Pather.moveTo(22638, me.y < target.y ? 15722 : 15693);
+				Pather.pathTo(22638, me.y < target.y ? 15722 : 15693);
 			}
 		}
 

--- a/d2bs/kolbot/libs/bots/Eldritch.js
+++ b/d2bs/kolbot/libs/bots/Eldritch.js
@@ -10,7 +10,7 @@ function Eldritch() {
 	Town.doChores();
 	Pather.useWaypoint(111);
 	Precast.doPrecast(true);
-	Pather.moveTo(3745, 5084);
+	Pather.pathTo(3745, 5084);
 	Attack.clear(15, 0, getLocaleString(22500)); // Eldritch the Rectifier
 
 	if (Config.Eldritch.OpenChest) {
@@ -21,19 +21,19 @@ function Eldritch() {
 
 			chest = getUnit(2, 455);
 
-			if (Misc.openChest(chest)) {
+			if (Chest.openChest(chest)) {
 				Pickit.pickItems();
 			}
 		}
 	}
 
 	if (Config.Eldritch.KillShenk) {
-		Pather.moveTo(3876, 5130);
+		Pather.pathTo(3876, 5130);
 		Attack.clear(15, 0, getLocaleString(22435)); // Shenk the Overseer
 	}
 
 	if (Config.Eldritch.KillDacFarren) {
-		Pather.moveTo(4478, 5108);
+		Pather.pathTo(4478, 5108);
 		Attack.clear(15, 0, getLocaleString(22501)); // Dac Farren
 	}
 

--- a/d2bs/kolbot/libs/bots/Enchant.js
+++ b/d2bs/kolbot/libs/bots/Enchant.js
@@ -162,7 +162,7 @@ function Enchant() {
 			return false;
 		}
 
-		Pather.moveTo(25048, 5177);
+		Pather.pathTo(25048, 5177);
 
 		wirt = getUnit(2, 268);
 
@@ -581,7 +581,7 @@ MainLoop:
 		}
 
 		if (spot && getDistance(me, spot) > 10) {
-			Pather.moveTo(spot.x, spot.y);
+			Pather.pathTo(spot.x, spot.y);
 		}
 
 		if (command && !this.floodCheck(command)) {

--- a/d2bs/kolbot/libs/bots/FastDiablo.js
+++ b/d2bs/kolbot/libs/bots/FastDiablo.js
@@ -73,7 +73,7 @@ function FastDiablo() {
 
 			for (i = 0; i < positions.length; i += 1) {
 				if (Attack.validSpot(target.x + positions[i][0], target.y + positions[i][1])) { // check if we can move there
-					Pather.moveTo(target.x + positions[i][0], target.y + positions[i][1]);
+					Pather.pathTo(target.x + positions[i][0], target.y + positions[i][1]);
 					Skill.setSkill(Config.AttackSkill[2], 0);
 
 					for (n = 0; n < amount; n += 1) {
@@ -197,9 +197,9 @@ function FastDiablo() {
 
 			if (!seal.mode) {
 				if (classid === 394 && Attack.validSpot(seal.x + 15, seal.y)) { // de seis optimization
-					Pather.moveTo(seal.x + 15, seal.y);
+					Pather.pathTo(seal.x + 15, seal.y);
 				} else {
-					Pather.moveTo(seal.x - 5, seal.y - 5);
+					Pather.pathTo(seal.x - 5, seal.y - 5);
 				}
 
 				delay(500);
@@ -219,9 +219,9 @@ function FastDiablo() {
 	this.openSeal(396);
 
 	if (this.vizLayout === 1) {
-		Pather.moveTo(7691, 5292);
+		Pather.pathTo(7691, 5292);
 	} else {
-		Pather.moveTo(7695, 5316);
+		Pather.pathTo(7695, 5316);
 	}
 
 	if (!this.getBoss(getLocaleString(2851))) {
@@ -231,9 +231,9 @@ function FastDiablo() {
 	this.openSeal(394);
 
 	if (this.seisLayout === 1) {
-		Pather.moveTo(7771, 5196);
+		Pather.pathTo(7771, 5196);
 	} else {
-		Pather.moveTo(7798, 5186);
+		Pather.pathTo(7798, 5186);
 	}
 
 	if (!this.getBoss(getLocaleString(2852))) {
@@ -246,14 +246,14 @@ function FastDiablo() {
 	if (this.infLayout === 1) {
 		delay(1);
 	} else {
-		Pather.moveTo(7928, 5295); // temp
+		Pather.pathTo(7928, 5295); // temp
 	}
 
 	if (!this.getBoss(getLocaleString(2853))) {
 		throw new Error("Failed to kill Infector");
 	}
 
-	Pather.moveTo(7788, 5292);
+	Pather.pathTo(7788, 5292);
 	this.diabloPrep();
 	Attack.kill(243); // Diablo
 	Pickit.pickItems();

--- a/d2bs/kolbot/libs/bots/Follower.js
+++ b/d2bs/kolbot/libs/bots/Follower.js
@@ -313,7 +313,7 @@ function Follower() {
 			target = getUnit(2, 342);
 
 			if (target) {
-				Pather.moveTo(target.x - 3, target.y - 1);
+				Pather.pathTo(target.x - 3, target.y - 1);
 			}
 
 			Pather.usePortal(null);
@@ -434,7 +434,7 @@ function Follower() {
 			unit = unitList.shift();
 
 			if (unit) {
-				Misc.openChest(unit);
+				Chest.openChest(unit);
 				Pickit.pickItems();
 			}
 		}
@@ -735,7 +735,7 @@ function Follower() {
 			break;
 		case "move":
 			coord = CollMap.getRandCoordinate(me.x, -5, 5, me.y, -5, 5);
-			Pather.moveTo(coord.x, coord.y);
+			Pather.pathTo(coord.x, coord.y);
 
 			break;
 		case "wp":

--- a/d2bs/kolbot/libs/bots/GhostBusters.js
+++ b/d2bs/kolbot/libs/bots/GhostBusters.js
@@ -27,7 +27,7 @@ function GhostBusters() {
 			result = Pather.getNearestWalkable(room[0], room[1], 15, 2);
 
 			if (result) {
-				Pather.moveTo(result[0], result[1], 3);
+				Pather.pathTo(result[0], result[1], 3);
 
 				monList = [];
 				monster = getUnit(1);

--- a/d2bs/kolbot/libs/bots/MFHelper.js
+++ b/d2bs/kolbot/libs/bots/MFHelper.js
@@ -125,7 +125,7 @@ function MFHelper() {
 			result = Pather.getNearestWalkable(room[0], room[1], 10, 2);
 
 			if (result) {
-				Pather.moveTo(result[0], result[1], 3);
+				Pather.pathTo(result[0], result[1], 3);
 
 				if (!Attack.clear(30)) {
 					return false;

--- a/d2bs/kolbot/libs/bots/Mephisto.js
+++ b/d2bs/kolbot/libs/bots/Mephisto.js
@@ -35,7 +35,7 @@ function Mephisto() {
 
 					if (Attack.validSpot(pos.x, pos.y)) {
 						me.overhead("move, bitch!");
-						Pather.moveTo(pos.x, pos.y);
+						Pather.pathTo(pos.x, pos.y);
 
 						break;
 					}
@@ -58,7 +58,7 @@ function Mephisto() {
 		count = 0;
 
 		delay(350);
-		Pather.moveTo(17563, 8072);
+		Pather.pathTo(17563, 8072);
 
 		mephisto = getUnit(1, 242);
 
@@ -67,40 +67,40 @@ function Mephisto() {
 		}
 
 		delay(350);
-		Pather.moveTo(17575, 8086);
+		Pather.pathTo(17575, 8086);
 		delay(350);
-		Pather.moveTo(17584, 8091);
+		Pather.pathTo(17584, 8091);
 		delay(1200);
-		Pather.moveTo(17600, 8095);
+		Pather.pathTo(17600, 8095);
 		delay(550);
-		Pather.moveTo(17610, 8094);
+		Pather.pathTo(17610, 8094);
 		delay(2500);
 		Attack.clear(10);
-		Pather.moveTo(17610, 8094);
+		Pather.pathTo(17610, 8094);
 
 		distance = getDistance(me, mephisto);
 
 		while (distance > 27) {
 			count += 1;
 
-			Pather.moveTo(17600, 8095);
+			Pather.pathTo(17600, 8095);
 			delay(150);
-			Pather.moveTo(17584, 8091);
+			Pather.pathTo(17584, 8091);
 			delay(150);
-			Pather.moveTo(17575, 8086);
+			Pather.pathTo(17575, 8086);
 			delay(150);
-			Pather.moveTo(17563, 8072);
+			Pather.pathTo(17563, 8072);
 			delay(350);
-			Pather.moveTo(17575, 8086);
+			Pather.pathTo(17575, 8086);
 			delay(350);
-			Pather.moveTo(17584, 8091);
+			Pather.pathTo(17584, 8091);
 			delay(1200);
-			Pather.moveTo(17600, 8095);
+			Pather.pathTo(17600, 8095);
 			delay(550);
-			Pather.moveTo(17610, 8094);
+			Pather.pathTo(17610, 8094);
 			delay(2500);
 			Attack.clear(10);
-			Pather.moveTo(17610, 8094);
+			Pather.pathTo(17610, 8094);
 
 			distance = getDistance(me, mephisto);
 
@@ -117,7 +117,7 @@ function Mephisto() {
 			coords = [17600, 8125, 17600, 8015, 17643, 8068];
 
 		for (i = 0; i < coords.length; i += 2) {
-			Pather.moveTo(coords[i], coords[i + 1]);
+			Pather.pathTo(coords[i], coords[i + 1]);
 
 			if (Config.MFLeader) {
 				Pather.makePortal();
@@ -142,7 +142,7 @@ function Mephisto() {
 		this.killCouncil();
 	}
 
-	Pather.moveTo(17566, 8069);
+	Pather.pathTo(17566, 8069);
 
 	if (me.classid === 1) {
 		if (Config.Mephisto.MoatTrick) {
@@ -164,18 +164,21 @@ function Mephisto() {
 	Pickit.pickItems();
 
 	if (Config.OpenChests) {
-		Pather.moveTo(17572, 8011);
-		Attack.openChests(5);
-		Pather.moveTo(17572, 8125);
-		Attack.openChests(5);
-		Pather.moveTo(17515, 8061);
-		Attack.openChests(5);
+		Pather.pathTo(17572, 8011);
+		Chest.scan(5);	//Chest stuff should no longer be necessary but leaving it here just in case
+		Chest.openChests();
+		Pather.pathTo(17572, 8125);
+		Chest.scan(5);
+		Chest.openChests();
+		Pather.pathTo(17515, 8061);
+		Chest.scan(5);
+		Chest.openChests();
 	}
 
 	if (Config.Mephisto.TakeRedPortal) {
-		Pather.moveTo(17590, 8068);
+		Pather.pathTo(17590, 8068);
 		delay(1500);
-		Pather.moveTo(17601, 8070);
+		Pather.pathTo(17601, 8070);
 		Pather.usePortal(null);
 	}
 

--- a/d2bs/kolbot/libs/bots/OrgTorch.js
+++ b/d2bs/kolbot/libs/bots/OrgTorch.js
@@ -11,7 +11,7 @@ function OrgTorch() {
 	// Identify & mule
 	this.checkTorch = function () {
 		if (me.area === 136) {
-			Pather.moveTo(25105, 5140);
+			Pather.pathTo(25105, 5140);
 			Pather.usePortal(109);
 		}
 
@@ -101,7 +101,7 @@ function OrgTorch() {
 				print("Getting Fade");
 				Pather.useWaypoint(107);
 				Precast.doPrecast(true);
-				Pather.moveTo(7811, 5872);
+				Pather.pathTo(7811, 5872);
 
 				if (me.classid === 3 && me.getSkill(125, 1)) {
 					Skill.setSkill(125, 0);
@@ -187,7 +187,7 @@ function OrgTorch() {
 			findLoc = [20196, 8694, 20308, 8588, 20187, 8639, 20100, 8550, 20103, 8688, 20144, 8709, 20263, 8811, 20247, 8665];
 
 			for (i = 0; i < findLoc.length; i += 2) {
-				Pather.moveTo(findLoc[i], findLoc[i + 1]);
+				Pather.pathTo(findLoc[i], findLoc[i + 1]);
 				delay(500);
 
 				if (getUnit(1, 708)) {
@@ -209,23 +209,23 @@ function OrgTorch() {
 
 			break;
 		case 136: // Tristram
-			Pather.moveTo(25068, 5078);
+			Pather.pathTo(25068, 5078);
 			Precast.doPrecast(true);
 
 			findLoc = [25040, 5101, 25040, 5166, 25122, 5170];
 
 			for (i = 0; i < findLoc.length; i += 2) {
-				Pather.moveTo(findLoc[i], findLoc[i + 1]);
+				Pather.pathTo(findLoc[i], findLoc[i + 1]);
 			}
 
 			Skill.setSkill(125, 0);
 			this.lure(704);
-			Pather.moveTo(25129, 5198);
+			Pather.pathTo(25129, 5198);
 			Skill.setSkill(125, 0);
 			this.lure(704);
 
 			if (!getUnit(1, 704)) {
-				Pather.moveTo(25122, 5170);
+				Pather.pathTo(25122, 5170);
 			}
 
 			if (Config.OrgTorch.UseSalvation && me.classid === 3 && me.getSkill(125, 1)) {
@@ -243,17 +243,17 @@ function OrgTorch() {
 				Attack.init();
 			}
 
-			Pather.moveTo(25162, 5141);
+			Pather.pathTo(25162, 5141);
 			delay(3250);
 
 			if (!getUnit(1, 709)) {
-				Pather.moveTo(25122, 5170);
+				Pather.pathTo(25122, 5170);
 			}
 
 			Attack.kill(709);
 
 			if (!getUnit(1, 705)) {
-				Pather.moveTo(25122, 5170);
+				Pather.pathTo(25122, 5170);
 			}
 
 			Attack.kill(705);

--- a/d2bs/kolbot/libs/bots/Pindleskin.js
+++ b/d2bs/kolbot/libs/bots/Pindleskin.js
@@ -36,7 +36,7 @@ function Pindleskin() {
 		Precast.doPrecast(true);
 	}
 
-	Pather.moveTo(10058, 13234);
+	Pather.pathTo(10058, 13234);
 
 	try {
 		Attack.clear(15, 0, getLocaleString(22497)); // Pindleskin

--- a/d2bs/kolbot/libs/bots/Questing.js
+++ b/d2bs/kolbot/libs/bots/Questing.js
@@ -140,7 +140,7 @@ function Questing() {
 
 		stand = getUnit(2, 193);
 
-		Misc.openChest(stand);
+		Chest.openChest(stand);
 		delay(300);
 
 		book = getUnit(4, 548);
@@ -173,7 +173,7 @@ function Questing() {
 		}
 
 		Precast.doPrecast(true);
-		Pather.moveTo(3883, 5113);
+		Pather.pathTo(3883, 5113);
 		Attack.kill(getLocaleString(22435)); // Shenk the Overseer
 		Town.goToTown();
 

--- a/d2bs/kolbot/libs/bots/Radament.js
+++ b/d2bs/kolbot/libs/bots/Radament.js
@@ -15,7 +15,8 @@ function Radament() {
 
 	Attack.kill(229); // Radament
 	Pickit.pickItems();
-	Attack.openChests(20);
+	Chest.scan(20);
+	Chest.openChests();
 
 	return true;
 }

--- a/d2bs/kolbot/libs/bots/Rakanishu.js
+++ b/d2bs/kolbot/libs/bots/Rakanishu.js
@@ -20,7 +20,7 @@ function Rakanishu() {
 			throw new Error("Failed to move to Tristram");
 		}
 
-		Pather.moveTo(25149, 5180);
+		Pather.pathTo(25149, 5180);
 		Attack.clear(20, 0xF, 365); // Griswold
 	}
 

--- a/d2bs/kolbot/libs/bots/Rushee.js
+++ b/d2bs/kolbot/libs/bots/Rushee.js
@@ -78,7 +78,7 @@ function Rushee() {
 			return false;
 		}
 
-		Misc.openChest(chest);
+		Chest.openChest(chest);
 
 		item = getUnit(4, classid);
 
@@ -170,7 +170,7 @@ function Rushee() {
 			return false;
 		}
 
-		Misc.openChest(orifice);
+		Chest.openChest(orifice);
 
 		staff = me.getItem(91);
 
@@ -241,7 +241,7 @@ function Rushee() {
 				npc = getUnit(1, NPC.Jerhyn);
 
 				if (!npc || !npc.openMenu()) {
-					Pather.moveTo(5166, 5206);
+					Pather.pathTo(5166, 5206);
 
 					return false;
 				}
@@ -280,7 +280,7 @@ function Rushee() {
 					delay(1500);
 				}
 
-				Pather.moveTo(17591, 8070);
+				Pather.pathTo(17591, 8070);
 				Pather.usePortal(null);
 
 				break;
@@ -515,7 +515,7 @@ function Rushee() {
 
 						target = getUnit(2, 193);
 
-						Misc.openChest(target);
+						Chest.openChest(target);
 						delay(300);
 
 						target = getUnit(4, 548);
@@ -553,7 +553,7 @@ function Rushee() {
 						break;
 					case 108: // Chaos Sanctuary
 						Pather.usePortal(108, Config.Leader);
-						Pather.moveTo(7762, 5268);
+						Pather.pathTo(7762, 5268);
 						Packet.flash(me.gid);
 						delay(500);
 						Pather.walkTo(7763, 5267, 2);
@@ -562,7 +562,7 @@ function Rushee() {
 							delay(500);
 						}
 
-						Pather.moveTo(7763, 5267);
+						Pather.pathTo(7763, 5267);
 						actions.shift();
 
 						break;

--- a/d2bs/kolbot/libs/bots/SealLeader.js
+++ b/d2bs/kolbot/libs/bots/SealLeader.js
@@ -59,7 +59,7 @@ function SealLeader() {
 
 			for (i = 0; i < positions.length; i += 1) {
 				if (Attack.validSpot(target.x + positions[i][0], target.y + positions[i][1])) { // check if we can move there
-					Pather.moveTo(target.x + positions[i][0], target.y + positions[i][1]);
+					Pather.pathTo(target.x + positions[i][0], target.y + positions[i][1]);
 					Skill.setSkill(Config.AttackSkill[2], 0);
 
 					for (n = 0; n < amount; n += 1) {
@@ -183,9 +183,9 @@ function SealLeader() {
 
 			if (!seal.mode) {
 				if (classid === 394 && Attack.validSpot(seal.x + 15, seal.y)) { // de seis optimization
-					Pather.moveTo(seal.x + 15, seal.y);
+					Pather.pathTo(seal.x + 15, seal.y);
 				} else {
-					Pather.moveTo(seal.x - 5, seal.y - 5);
+					Pather.pathTo(seal.x - 5, seal.y - 5);
 				}
 
 				delay(500);
@@ -204,9 +204,9 @@ function SealLeader() {
 	this.initLayout();
 
 	if (this.vizLayout === 1) {
-		Pather.moveTo(7708, 5269);
+		Pather.pathTo(7708, 5269);
 	} else {
-		Pather.moveTo(7647, 5267);
+		Pather.pathTo(7647, 5267);
 	}
 
 	Attack.securePosition(me.x, me.y, 35, 3000, true);
@@ -216,9 +216,9 @@ function SealLeader() {
 	this.openSeal(396);
 
 	if (this.vizLayout === 1) {
-		Pather.moveTo(7691, 5292);
+		Pather.pathTo(7691, 5292);
 	} else {
-		Pather.moveTo(7695, 5316);
+		Pather.pathTo(7695, 5316);
 	}
 
 	// Kill Viz
@@ -229,9 +229,9 @@ function SealLeader() {
 	say("out");
 
 	if (this.seisLayout === 1) {
-		Pather.moveTo(7767, 5147);
+		Pather.pathTo(7767, 5147);
 	} else {
-		Pather.moveTo(7820, 5147);
+		Pather.pathTo(7820, 5147);
 	}
 
 	Attack.securePosition(me.x, me.y, 35, 3000, true);
@@ -240,9 +240,9 @@ function SealLeader() {
 	this.openSeal(394);
 
 	if (this.seisLayout === 1) {
-		Pather.moveTo(7771, 5196);
+		Pather.pathTo(7771, 5196);
 	} else {
-		Pather.moveTo(7798, 5186);
+		Pather.pathTo(7798, 5186);
 	}
 
 	if (!this.getBoss(getLocaleString(2852))) {
@@ -252,9 +252,9 @@ function SealLeader() {
 	say("out");
 
 	if (this.infLayout === 1) {
-		Pather.moveTo(7860, 5314);
+		Pather.pathTo(7860, 5314);
 	} else {
-		Pather.moveTo(7909, 5317);
+		Pather.pathTo(7909, 5317);
 	}
 
 	Attack.securePosition(me.x, me.y, 35, 3000, true);
@@ -263,7 +263,7 @@ function SealLeader() {
 	this.openSeal(392);
 
 	if (this.infLayout === 2) {
-		Pather.moveTo(7928, 5295);
+		Pather.pathTo(7928, 5295);
 	}
 
 	if (!this.getBoss(getLocaleString(2853))) {
@@ -272,9 +272,9 @@ function SealLeader() {
 
 	this.openSeal(393);
 	say("out");
-	Pather.moveTo(7763, 5267);
+	Pather.pathTo(7763, 5267);
 	Pather.makePortal();
-	Pather.moveTo(7788, 5292);
+	Pather.pathTo(7788, 5292);
 	say("in");
 	this.diabloPrep();
 	Attack.kill(243); // Diablo

--- a/d2bs/kolbot/libs/bots/Travincal.js
+++ b/d2bs/kolbot/libs/bots/Travincal.js
@@ -30,11 +30,11 @@ function Travincal() {
 	orgY = me.y;
 
 	if (Config.Travincal.PortalLeech) {
-		Pather.moveTo(orgX + 85, orgY - 139);
+		Pather.pathTo(orgX + 85, orgY - 139);
 		Attack.securePosition(orgX + 70, orgY - 139, 25, 2000);
 		Attack.securePosition(orgX + 100, orgY - 139, 25, 2000);
 		Attack.securePosition(orgX + 85, orgY - 139, 25, 5000);
-		Pather.moveTo(orgX + 85, orgY - 139);
+		Pather.pathTo(orgX + 85, orgY - 139);
 		Pather.makePortal();
 		delay(1000);
 		Precast.doPrecast(true);
@@ -45,7 +45,7 @@ function Travincal() {
 
 		for (i = 0; i < coords.length; i += 2) {
 			if (i % 4 === 0) {
-				Pather.moveTo(orgX + coords[i], orgY + coords[i + 1]);
+				Pather.pathTo(orgX + coords[i], orgY + coords[i + 1]);
 			} else {
 				Skill.cast(143, 0, orgX + coords[i], orgY + coords[i + 1]);
 				Attack.clearList(this.buildList(1));
@@ -54,7 +54,7 @@ function Travincal() {
 
 		Attack.clearList(this.buildList(0));
 	} else {
-		Pather.moveTo(orgX + 101, orgY - 56);
+		Pather.pathTo(orgX + 101, orgY - 56);
 
 		// Stack Merc
 		if (me.classid === 4 && !me.getSkill(54, 1) && me.gametype === 1) {

--- a/d2bs/kolbot/libs/bots/Tristram.js
+++ b/d2bs/kolbot/libs/bots/Tristram.js
@@ -20,7 +20,7 @@ function Tristram() {
 
 			tree = getUnit(2, 30);
 
-			Misc.openChest(tree);
+			Chest.openChest(tree);
 			delay(300);
 
 			scroll = getUnit(4, 524);
@@ -67,7 +67,7 @@ function Tristram() {
 		Attack.securePosition(me.x, me.y, 10, 1000);
 	}
 
-	Pather.moveTo(me.x, me.y + 6);
+	Pather.pathTo(me.x, me.y + 6);
 
 	if (Config.Tristram.PortalLeech) {
 		Pather.makePortal();
@@ -82,7 +82,7 @@ function Tristram() {
 			throw new Error("Failed to move to Cain's Gibbet");
 		}
 
-		Misc.openChest(gibbet);
+		Chest.openChest(gibbet);
 	}
 
 	if (Config.Tristram.PortalLeech) {

--- a/d2bs/kolbot/libs/bots/TristramLeech.js
+++ b/d2bs/kolbot/libs/bots/TristramLeech.js
@@ -86,13 +86,13 @@ function TristramLeech() {
 						Attack.clear(10);
 					}
 				} else {
-						Pather.moveTo(copyUnit(leaderUnit).x, copyUnit(leaderUnit).y);
+						Pather.pathTo(copyUnit(leaderUnit).x, copyUnit(leaderUnit).y);
 						Attack.clear(10);
 				}
 			}
 			catch(err){
 				if (whereisleader.area === me.area){
-					Pather.moveTo(whereisleader.x, whereisleader.y);
+					Pather.pathTo(whereisleader.x, whereisleader.y);
 					Attack.clear(10);
 				}
 			}

--- a/d2bs/kolbot/libs/bots/Wakka.js
+++ b/d2bs/kolbot/libs/bots/Wakka.js
@@ -221,7 +221,7 @@ function Wakka() {
 				}
 			}
 
-			if (Pather.moveTo(path[0].x, path[0].y)) {
+			if (Pather.pathTo(path[0].x, path[0].y)) {
 				path.shift();
 			}
 
@@ -360,7 +360,7 @@ function Wakka() {
 					break;
 				}
 
-				Pather.moveTo(7767, 5263);
+				Pather.pathTo(7767, 5263);
 
 				diablo = getUnit(1, 243);
 

--- a/d2bs/kolbot/libs/common/Attack.js
+++ b/d2bs/kolbot/libs/common/Attack.js
@@ -515,7 +515,7 @@ var Attack = {
 						if (gidAttack[i].attacks > 0 && gidAttack[i].attacks % ((target.spectype & 0x7) ? 4 : 2) === 0) {
 							//print("random move m8");
 							coord = CollMap.getRandCoordinate(me.x, -1, 1, me.y, -1, 1, 5);
-							Pather.moveTo(coord.x, coord.y);
+							Pather.pathTo(coord.x, coord.y);
 						}
 
 						break;
@@ -551,7 +551,6 @@ var Attack = {
 		}
 
 		ClassAttack.afterAttack(pickit);
-		this.openChests(range, orgx, orgy);
 
 		if (attackCount > 0 && pickit) {
 			Pickit.pickItems();
@@ -684,7 +683,7 @@ var Attack = {
 						// Tele in random direction with Blessed Hammer
 						if (gidAttack[i].attacks > 0 && gidAttack[i].attacks % ((target.spectype & 0x7) ? 5 : 15) === 0) {
 							coord = CollMap.getRandCoordinate(me.x, -1, 1, me.y, -1, 1, 4);
-							Pather.moveTo(coord.x, coord.y);
+							Pather.pathTo(coord.x, coord.y);
 						}
 
 						break;
@@ -722,7 +721,6 @@ var Attack = {
 		}
 
 		ClassAttack.afterAttack(true);
-		this.openChests(30);
 
 		if (attackCount > 0) {
 			Pickit.pickItems();
@@ -744,7 +742,7 @@ var Attack = {
 
 		while (true) {
 			if (getDistance(me, x, y) > 5) {
-				Pather.moveTo(x, y);
+				Pather.pathTo(x, y);
 			}
 
 			monster = getUnit(1);
@@ -905,7 +903,7 @@ var Attack = {
 			result = Pather.getNearestWalkable(room[0], room[1], 18, 3);
 
 			if (result) {
-				Pather.moveTo(result[0], result[1], 3, spectype);
+				Pather.pathTo(result[0], result[1], 3, spectype, true);
 				previousArea = result;
 				//this.countUniques();
 
@@ -915,7 +913,7 @@ var Attack = {
 			}
 			// Make sure bot does not get stuck in different area.
 			else if (currentArea !== getArea().id) {
-				Pather.moveTo(previousArea[0], previousArea[1], 3, spectype);
+				Pather.pathTo(previousArea[0], previousArea[1], 3, spectype);
 			}
 		}
 
@@ -1008,42 +1006,6 @@ var Attack = {
 		return true;
 	},
 
-	// Open chests when clearing
-	openChests: function (range, x, y) {
-		if (!Config.OpenChests) {
-			return false;
-		}
-
-		if (x === undefined || y === undefined) {
-			x = me.x;
-			y = me.y;
-		}
-
-		var i, unit,
-			list = [],
-			ids = ["chest", "chest3", "weaponrack", "armorstand"];
-
-		unit = getUnit(2);
-
-		if (unit) {
-			do {
-				if (unit.name && getDistance(unit, x, y) <= range && ids.indexOf(unit.name.toLowerCase()) > -1) {
-					list.push(copyUnit(unit));
-				}
-			} while (unit.getNext());
-		}
-
-		while (list.length) {
-			list.sort(Sort.units);
-
-			if (Misc.openChest(list.shift())) {
-				Pickit.pickItems();
-			}
-		}
-
-		return true;
-	},
-
 	buildMonsterList: function () {
 		var monster,
 			monList = [];
@@ -1120,7 +1082,7 @@ var Attack = {
 		if (typeof index === "number") {
 			//print("Dodge build time: " + (getTickCount() - tick));
 
-			return Pather.moveTo(grid[index].x, grid[index].y, 0);
+			return Pather.pathTo(grid[index].x, grid[index].y, 0);
 		}
 
 		return false;
@@ -1550,7 +1512,7 @@ AuraLoop: // Skip monsters with auras
 					Pather.walkTo(unit.x, unit.y, 3);
 				}
 			} else {
-				Pather.moveTo(unit.x, unit.y, 0);
+				Pather.maneuverTo(unit.x, unit.y, 0);
 			}
 
 			return !CollMap.checkColl(me, unit, coll);
@@ -1598,12 +1560,12 @@ AuraLoop: // Skip monsters with auras
 							if (getDistance(me, coords[i]) < 6 && !CollMap.checkColl(me, coords[i], 0x5)) {
 								Pather.walkTo(coords[i].x, coords[i].y, 2);
 							} else {
-								Pather.moveTo(coords[i].x, coords[i].y, 1);
+								Pather.maneuverTo(coords[i].x, coords[i].y, 1);
 							}
 
 							break;
 						default:
-							Pather.moveTo(coords[i].x, coords[i].y, 1);
+							Pather.maneuverTo(coords[i].x, coords[i].y, 1, true);
 
 							break;
 						}

--- a/d2bs/kolbot/libs/common/Attacks/Paladin.js
+++ b/d2bs/kolbot/libs/common/Attacks/Paladin.js
@@ -231,7 +231,7 @@ var ClassAttack = {
 			cy = Math.round(Math.sin(i) * distance);
 
 			if (Attack.validSpot(unit.x + cx, unit.y + cy)) {
-				return Pather.moveTo(unit.x + cx, unit.y + cy);
+				return Pather.pathTo(unit.x + cx, unit.y + cy);
 			}
 		}
 
@@ -295,7 +295,7 @@ var ClassAttack = {
 		if (Math.round(getDistance(me, x, y) > 0)) {
 			if (Pather.teleport && !me.inTown && me.getStat(97, 54)) {
 				if (getDistance(me, x, y) > 40) {
-					Pather.moveTo(x, y);
+					Pather.pathTo(x, y);
 				} else {
 					Pather.teleportTo(x, y, 3);
 				}

--- a/d2bs/kolbot/libs/common/Cubing.js
+++ b/d2bs/kolbot/libs/common/Cubing.js
@@ -160,7 +160,7 @@ var Cubing = {
 			chest = getUnit(2, 354);
 
 			if (chest) {
-				Misc.openChest(chest);
+				Chest.openChest(chest);
 
 				for (i = 0; i < 5; i += 1) {
 					cube = getUnit(4, 549);

--- a/d2bs/kolbot/libs/common/Misc.js
+++ b/d2bs/kolbot/libs/common/Misc.js
@@ -747,7 +747,9 @@ var Item = {
 		}
 
 		return true;
-	},
+	}
+	
+}
 
 var Chest = {
 	chestList: [],

--- a/d2bs/kolbot/libs/common/Misc.js
+++ b/d2bs/kolbot/libs/common/Misc.js
@@ -747,7 +747,346 @@ var Item = {
 		}
 
 		return true;
+	},
+
+var Chest = {
+	chestList: [],
+	allowScan: true,
+	openingChests: false,
+	currentChestGid: null,
+	containers_limited: [
+		"chest", "chest3", "armorstand", "weaponrack"
+	],
+	containers_all: [
+		"chest", "loose rock", "hidden stash", "loose boulder", "corpseonstick", "casket", "armorstand", "weaponrack", "barrel", "holeanim", "tomb2",
+		"tomb3", "roguecorpse", "ratnest", "corpse", "goo pile", "largeurn", "urn", "chest3", "jug", "skeleton", "guardcorpse", "sarcophagus", "object2",
+		"cocoon", "basket", "stash", "hollow log", "hungskeleton", "pillar", "skullpile", "skull pile", "jar3", "jar2", "jar1", "bonechest", "woodchestl",
+		"woodchestr", "barrel wilderness", "burialchestr", "burialchestl", "explodingchest", "chestl", "chestr", "groundtomb", "icecavejar1", "icecavejar2",
+		"icecavejar3", "icecavejar4", "deadperson", "deadperson2", "evilurn", "tomb1l", "tomb3l", "groundtombl"
+	],
+	
+	scan: function(range) {		
+		var containers = [],
+			unit,
+			scanned = 0;
+		
+		if (!range)
+			range = 15;
+		
+		if (Config.OpenChests === 2)
+			containers = this.containers_all;
+		else
+			containers = this.containers_limited;
+		
+		unit = getUnit(2, null, 0);
+		
+		if (unit) {
+			do {
+				if (containers.indexOf(unit.name.toLowerCase()) > -1
+					&& getDistance(me.x, me.y, unit.x, unit.y) <= range) {
+					this.addChest(unit);
+					scanned++;
+				}
+				
+			} while (unit.getNext());
+			
+		}
+		
+		this.clean();
+		
+		//print("scanned/total chests: " + scanned + " - " + this.chestList.length);
+		
+	},
+	
+	isValid: function(unit) {
+		if (unit === undefined || typeof unit !== "object")
+			return false;
+		
+		//Don't add chests that aren't in the same area
+		if (me.area !== unit.area) {
+			//print("Chest.isValid: Not in the same area (" + me.area + ":" + unit.area + ")");
+			return false;
+			
+		}
+		
+		if (this.containers_all.indexOf(unit.name.toLowerCase()) <= -1) {
+			//print("Chest.isValid: Not a typical chest - " + unit.name);
+			return false;
+			
+		}
+		
+		//Don't add chests that are already open or are disappeared
+		if (unit.mode === undefined || unit.mode === null || unit.mode >= 1) {
+			//print("Chest.isValid:  Mode is " + unit.mode + "(" + unit.name + ")");
+			return false;
+			
+		}
+		
+		if (unit.x === undefined || unit.x === null) {
+			//print("Chest.isValid: Unit.x is undefined");
+			return false;
+			
+		}
+		
+		return true;
+		
+	},
+	
+	addChests: function(units) {
+		if (units === undefined || !Array.isArray(units))
+			throw new Error("Chest.addChests: Invalid parameter supplied");
+		
+		for (var i = 0; i < units.length; i++) {
+			this.addChest(units[i]);
+			
+		}
+		
+		this.clean();
+		
+	},
+	
+	addChest: function(unit) {		
+		if (!this.isValid(unit) || this.chestListContains(unit))
+			return;
+		
+		this.chestList.push(copyUnit(unit));
+		//print("Added chest #" + this.chestList.length + " GID " + unit.gid);
+		
+	},
+	
+	chestListContains: function(unit) {
+		if (!unit)
+			throw new Error("Unit is required");
+		
+		for (var i = 0; i < this.chestList.length; i++) {
+			if (this.chestList[i].gid === unit.gid)
+				return true;
+			
+		}
+		
+		return false;
+		
+	},
+	
+	clean: function() {
+		
+		if (this.chestList.length === 0) {
+			this.openingChests = false;
+			return;
+			
+		}
+		
+		for (var i = this.chestList.length - 1; i >= 0; i--) {
+			if (!this.isValid(this.chestList[i])) {
+				//print("Splicing out chest " + this.chestList[i].gid);
+				this.chestList.splice(i, 1);
+			
+			}		
+			
+		}
+		
+		if (this.chestList.length === 0)
+			this.openingChests = false;
+		
+	},
+	
+	// Open a chest Unit
+	openChest: function (unit) {
+		// Skip invalid and Countess chests
+		if (!unit || unit.x === 12526 || unit.x === 12565) {
+			return false;
+		}
+		
+		//Don't bother if the chest is in a wierd spot
+		if (!Attack.validSpot(unit.x + 1, unit.y + 2)) {
+			return false;
+		}
+
+		// locked chest, no keys
+		if (me.classid !== 6 && unit.islocked && !me.findItem(543, 0, 3)) {
+			return false;
+		}
+
+		var i, tick;
+		var clearPath = !Pather.useTeleport();
+
+		for (i = 0; i < 3; i += 1) {
+			// already open
+			if (!unit || unit.gid === undefined || unit.mode) {
+				print("chest already open: " + unit);
+				return true;
+			}
+			
+			if (Pather.pathTo(unit.x + 1, unit.y + 2, 0, clearPath) && getDistance(me, unit.x + 1, unit.y + 2) < 5) {
+				
+				//Misc.click(0, 0, unit);
+				sendPacket(1, 0x13, 4, unit.type, 4, unit.gid);
+				
+			}
+			else
+				delay(40);	//Wait a bit
+			
+			PathDebug.drawPath([{x: unit.x, y: unit.y}], 0xFF);
+
+			tick = getTickCount();
+			
+			while (getTickCount() - tick < 1000) {
+				if (unit.gid === undefined || unit.mode > 1) {
+					
+					return true;
+				}
+
+				delay(10);
+			}
+		}
+
+		if (!me.idle) {
+			Misc.click(0, 0, me.x, me.y); // Click to stop walking in case we got stuck
+		}
+
+		return false;
+	},
+	
+	openChests: function() {
+		if (this.chestList.length === 0) {
+			this.openingChests = false;
+			return;
+			
+		}
+		if (this.openingChests)
+			return;
+		
+		this.openingChests = true;
+		
+		var chestsToOpen = this.chestList.slice();
+		
+		chestsToOpen.sort(Sort.units);
+		
+		for (var i = 0; i < chestsToOpen.length; i++) {
+			var chest = getUnit(2, null, 0, chestsToOpen[i].gid);
+			if (chest === undefined) {
+				Chest.removeChest(chestsToOpen[i].gid);
+				continue;
+			} else
+				chestsToOpen[i] = chest;
+			
+			if (this.isValid(chestsToOpen[i])/* && (Pather.useTeleport() || !checkCollision(me, chestsToOpen[i], 0x4))*/) {
+				//print("opening Chest " + chestsToOpen[i].name + " - " + chestsToOpen[i].gid + " mode: " + chestsToOpen[i].mode);
+
+				if (Chest.openChest(chestsToOpen[i])) {
+					Pickit.pickItems();
+					
+				}
+				
+			}
+			
+			//During opening chests we might find more chests to open.  If so, then basically
+			//start over by openening the chests starting from the closest one to the bot
+			if (chestsToOpen.length < this.chestList.length) {
+				Chest.removeChest(chestsToOpen[i].gid);
+				chestsToOpen = this.chestList.slice();
+				i = -1;	//Start over (will be incremented to 0)
+				chestsToOpen.sort(Sort.units);
+				
+			}
+			else
+				Chest.removeChest(chestsToOpen[i].gid);
+			
+		}
+		
+		this.openingChests = false;
+		
+	},
+	
+	// Open all chests that have preset units in an area
+	openChestsInArea: function (area, chestIds) {
+		var i, coords, presetUnits;
+
+		if (!area) {
+			area = me.area;
+		}
+
+		// testing
+		if (area !== me.area) {
+			Pather.journeyTo(area);
+		}
+
+		coords = [];
+		presetUnits = getPresetUnits(area, 2);
+
+		if (!chestIds) {
+			chestIds = [
+				5, 6, 87, 104, 105, 106, 107, 143, 140, 141, 144, 146, 147, 148, 176, 177, 181, 183, 198, 240, 241,
+				242, 243, 329, 330, 331, 332, 333, 334, 335, 336, 354, 355, 356, 371, 387, 389, 390, 391, 397, 405,
+				406, 407, 413, 420, 424, 425, 430, 431, 432, 433, 454, 455, 501, 502, 504, 505, 580, 581
+			];
+		}
+
+		if (!presetUnits) {
+			return false;
+		}
+
+		while (presetUnits.length > 0) {
+			if (chestIds.indexOf(presetUnits[0].id) > -1) {
+				coords.push({
+					x: presetUnits[0].roomx * 5 + presetUnits[0].x,
+					y: presetUnits[0].roomy * 5 + presetUnits[0].y
+				});
+			}
+
+			presetUnits.shift();
+		}
+
+		while (coords.length) {
+			coords.sort(Sort.units);
+			Pather.moveToUnit(coords[0], 1, 2);
+			this.openChests(20);
+
+			for (i = 0; i < coords.length; i += 1) {
+				if (getDistance(coords[i].x, coords[i].y, coords[0].x, coords[0].y) < 20) {
+					coords.shift();
+				}
+			}
+		}
+
+		return true;
+	},
+	
+	getNext: function() {
+		if (this.chestList.length === 0)
+			return null;
+		
+		return this.chestList[0];
+		
+	},
+	
+	removeChest: function(gid) {
+		if (this.chestList.length === 0)
+			return;
+			
+		for (var i = 0; i < this.chestList.length; i++) {
+			if (this.chestList[i].gid === gid) {
+				this.chestList.splice(i, 1);
+				return;
+				
+			}
+		}
+		
+	},
+	
+	debugPrintChests: function() {
+		var str = "Chest.chestList: [";
+		
+		for (var i = 0; i < this.chestList.length; i++) {
+			str += "{" + this.chestList[i].gid + ", " + this.chestList[i].mode + ", " + this.chestList[i].name + "}";
+		}
+		
+		str += "]";
+		
+		print(str);
+		
 	}
+	
 };
 
 var Misc = {
@@ -865,146 +1204,6 @@ var Misc = {
 		}
 
 		return count;
-	},
-
-	// Open a chest Unit
-	openChest: function (unit) {
-		// Skip invalid and Countess chests
-		if (!unit || unit.x === 12526 || unit.x === 12565) {
-			return false;
-		}
-
-		// already open
-		if (unit.mode) {
-			return true;
-		}
-
-		// locked chest, no keys
-		if (me.classid !== 6 && unit.islocked && !me.findItem(543, 0, 3)) {
-			return false;
-		}
-
-		var i, tick;
-
-		for (i = 0; i < 3; i += 1) {
-			if (Pather.moveTo(unit.x + 1, unit.y + 2, 3) && getDistance(me, unit.x + 1, unit.y + 2) < 5) {
-				//Misc.click(0, 0, unit);
-				sendPacket(1, 0x13, 4, unit.type, 4, unit.gid);
-			}
-
-			tick = getTickCount();
-
-			while (getTickCount() - tick < 1000) {
-				if (unit.mode) {
-					return true;
-				}
-
-				delay(10);
-			}
-		}
-
-		if (!me.idle) {
-			Misc.click(0, 0, me.x, me.y); // Click to stop walking in case we got stuck
-		}
-
-		return false;
-	},
-
-	// Open all chests that have preset units in an area
-	openChestsInArea: function (area, chestIds) {
-		var i, coords, presetUnits;
-
-		if (!area) {
-			area = me.area;
-		}
-
-		// testing
-		if (area !== me.area) {
-			Pather.journeyTo(area);
-		}
-
-		coords = [];
-		presetUnits = getPresetUnits(area, 2);
-
-		if (!chestIds) {
-			chestIds = [
-				5, 6, 87, 104, 105, 106, 107, 143, 140, 141, 144, 146, 147, 148, 176, 177, 181, 183, 198, 240, 241,
-				242, 243, 329, 330, 331, 332, 333, 334, 335, 336, 354, 355, 356, 371, 387, 389, 390, 391, 397, 405,
-				406, 407, 413, 420, 424, 425, 430, 431, 432, 433, 454, 455, 501, 502, 504, 505, 580, 581
-			];
-		}
-
-		if (!presetUnits) {
-			return false;
-		}
-
-		while (presetUnits.length > 0) {
-			if (chestIds.indexOf(presetUnits[0].id) > -1) {
-				coords.push({
-					x: presetUnits[0].roomx * 5 + presetUnits[0].x,
-					y: presetUnits[0].roomy * 5 + presetUnits[0].y
-				});
-			}
-
-			presetUnits.shift();
-		}
-
-		while (coords.length) {
-			coords.sort(Sort.units);
-			Pather.moveToUnit(coords[0], 1, 2);
-			this.openChests(20);
-
-			for (i = 0; i < coords.length; i += 1) {
-				if (getDistance(coords[i].x, coords[i].y, coords[0].x, coords[0].y) < 20) {
-					coords.shift();
-				}
-			}
-		}
-
-		return true;
-	},
-
-	openChests: function (range) {
-		var unit,
-			unitList = [],
-			containers = ["chest", "chest3", "armorstand", "weaponrack"];
-
-		if (!range) {
-			range = 15;
-		}
-
-		// Testing all container code
-		if (Config.OpenChests === 2) {
-			containers = [
-				"chest", "loose rock", "hidden stash", "loose boulder", "corpseonstick", "casket", "armorstand", "weaponrack", "barrel", "holeanim", "tomb2",
-				"tomb3", "roguecorpse", "ratnest", "corpse", "goo pile", "largeurn", "urn", "chest3", "jug", "skeleton", "guardcorpse", "sarcophagus", "object2",
-				"cocoon", "basket", "stash", "hollow log", "hungskeleton", "pillar", "skullpile", "skull pile", "jar3", "jar2", "jar1", "bonechest", "woodchestl",
-				"woodchestr", "barrel wilderness", "burialchestr", "burialchestl", "explodingchest", "chestl", "chestr", "groundtomb", "icecavejar1", "icecavejar2",
-				"icecavejar3", "icecavejar4", "deadperson", "deadperson2", "evilurn", "tomb1l", "tomb3l", "groundtombl"
-			];
-		}
-
-		unit = getUnit(2);
-
-		if (unit) {
-			do {
-				if (unit.name && unit.mode === 0 && getDistance(me.x, me.y, unit.x, unit.y) <= range && containers.indexOf(unit.name.toLowerCase()) > -1) {
-					unitList.push(copyUnit(unit));
-				}
-			} while (unit.getNext());
-		}
-
-		while (unitList.length > 0) {
-			unitList.sort(Sort.units);
-
-			unit = unitList.shift();
-
-			if (unit && (Pather.useTeleport() || !checkCollision(me, unit, 0x4)) && this.openChest(unit)) {
-				Pickit.pickItems();
-			}
-		}
-
-		return true;
 	},
 
 	shrineStates: false,
@@ -1150,14 +1349,14 @@ var Misc = {
 
 			coords = shrineLocs.shift();
 
-			Pather.moveTo(coords[0], coords[1], 2);
+			Pather.pathTo(coords[0], coords[1], 2);
 
 			shrine = getUnit(2, "shrine");
 
 			if (shrine) {
 				do {
 					if (shrine.objtype === type && shrine.mode === 0) {
-						Pather.moveTo(shrine.x - 2, shrine.y - 2);
+						Pather.pathTo(shrine.x - 2, shrine.y - 2);
 
 						if (!use || this.getShrine(shrine)) {
 							return true;

--- a/d2bs/kolbot/libs/common/Pather.js
+++ b/d2bs/kolbot/libs/common/Pather.js
@@ -78,7 +78,7 @@ var NodeAction = {
 
 var PathDebug = {
 	hooks: [],
-	enableHooks: true,
+	enableHooks: false,
 
 	drawPath: function (path, color, clear) {
 		if (!this.enableHooks) {

--- a/d2bs/kolbot/libs/common/Pickit.js
+++ b/d2bs/kolbot/libs/common/Pickit.js
@@ -254,8 +254,11 @@ MainLoop:
 			if (me.dead) {
 				return false;
 			}
+			
+			//print("Picking item");
 
 			while (!me.idle) {
+				//print("Pickit:  Waiting");
 				delay(40);
 			}
 
@@ -267,9 +270,10 @@ MainLoop:
 				Skill.cast(43, 0, item);
 			} else {
 				if (getDistance(me, item) > (Config.FastPick === 2 && i < 1 ? 6 : 4) || checkCollision(me, item, 0x1)) {
+					
 					if (Pather.useTeleport()) {
 						Pather.moveToUnit(item);
-					} else if (!Pather.moveTo(item.x, item.y, 0)) {
+					} else if (!Pather.maneuverTo(item.x, item.y, 0)) {
 						continue MainLoop;
 					}
 				}

--- a/d2bs/kolbot/libs/common/Town.js
+++ b/d2bs/kolbot/libs/common/Town.js
@@ -1659,7 +1659,7 @@ MainLoop:
 
 			if (getTickCount() - timer > 3000) {
 				coord = CollMap.getRandCoordinate(me.x, -1, 1, me.y, -1, 1, 4);
-				Pather.moveTo(coord.x, coord.y);
+				Pather.pathTo(coord.x, coord.y);
 			}
 
 			if (getTickCount() - timer > 30000) {
@@ -2095,7 +2095,7 @@ MainLoop:
 			//print("moveToSpot: " + spot + " from " + me.x + ", " + me.y);
 
 			if (getDistance(me, townSpot[i], townSpot[i + 1]) > 2) {
-				Pather.moveTo(townSpot[i], townSpot[i + 1], 3, false, true);
+				Pather.pathTo(townSpot[i], townSpot[i + 1], 3, false, true);
 			}
 
 			switch (spot) {

--- a/d2bs/kolbot/tools/AntiHostile.js
+++ b/d2bs/kolbot/tools/AntiHostile.js
@@ -176,7 +176,7 @@ function main() {
 			coordy = Math.round((Math.sin((angle + angles[i]) * Math.PI / 180)) * range + unit.y); // unit.targety
 
 			if (Attack.validSpot(coordx, coordy)) {
-				return Pather.moveTo(coordx, coordy);
+				return Pather.pathTo(coordx, coordy);
 			}
 		}
 
@@ -216,7 +216,7 @@ function main() {
 				case 1: // Sorceress
 					prevPos = {x: me.x, y: me.y};
 					this.pause();
-					Pather.moveTo(15103, 5247);
+					Pather.pathTo(15103, 5247);
 
 					while (!this.findPlayer() && hostiles.length > 0) {
 						if (!me.getState(121)) {
@@ -241,7 +241,7 @@ function main() {
 
 					prevPos = {x: me.x, y: me.y};
 					this.pause();
-					Pather.moveTo(15103, 5247);
+					Pather.pathTo(15103, 5247);
 
 					while (!this.findPlayer() && hostiles.length > 0) {
 						// Tornado path is a function of target x. Slight randomization will make sure it can't always miss
@@ -252,7 +252,7 @@ function main() {
 				case 6: // Assassin
 					prevPos = {x: me.x, y: me.y};
 					this.pause();
-					Pather.moveTo(15103, 5247);
+					Pather.pathTo(15103, 5247);
 
 					while (!this.findPlayer() && hostiles.length > 0) {
 						if (Config.UseTraps) {
@@ -276,7 +276,7 @@ function main() {
 
 			// Player left, return to old position
 			if (!hostiles.length && prevPos) {
-				Pather.moveTo(prevPos.x, prevPos.y);
+				Pather.pathTo(prevPos.x, prevPos.y);
 				this.resume();
 
 				// Reset position
@@ -363,7 +363,7 @@ function main() {
 					}
 				}
 
-				Pather.moveTo(prevPos.x, prevPos.y);
+				Pather.pathTo(prevPos.x, prevPos.y);
 				this.resume();
 			}
 		}

--- a/d2bs/kolbot/tools/RushThread.js
+++ b/d2bs/kolbot/tools/RushThread.js
@@ -103,7 +103,7 @@ function main() {
 		Pather.useWaypoint(35, true);
 		Precast.doPrecast(true);
 
-		if (!Pather.moveToExit([36, 37], true) || !Pather.moveTo(22582, 9612)) {
+		if (!Pather.moveToExit([36, 37], true) || !Pather.pathTo(22582, 9612)) {
 			throw new Error("andy failed");
 		}
 
@@ -112,13 +112,13 @@ function main() {
 		say("1");
 
 		while (!this.playerIn()) {
-			Pather.moveTo(22582, 9612);
+			Pather.pathTo(22582, 9612);
 			delay(250);
 		}
 
 		Attack.kill(156);
 		say("2");
-		Pather.moveTo(22582, 9612);
+		Pather.pathTo(22582, 9612);
 
 		while (this.playerIn()) {
 			delay(250);
@@ -169,7 +169,7 @@ function main() {
 		Pather.useWaypoint(44, true);
 		Precast.doPrecast(true);
 
-		if (!Pather.moveToExit([45, 58, 61], true) || !Pather.moveTo(15044, 14045)) {
+		if (!Pather.moveToExit([45, 58, 61], true) || !Pather.pathTo(15044, 14045)) {
 			throw new Error("amulet failed");
 		}
 
@@ -342,12 +342,12 @@ function main() {
 
 		Pather.teleport = false;
 
-		Pather.moveTo(22579, 15706);
+		Pather.pathTo(22579, 15706);
 
 		Pather.teleport = true;
 
-		Pather.moveTo(22577, 15649, 10);
-		Pather.moveTo(22577, 15609, 10);
+		Pather.pathTo(22577, 15649, 10);
+		Pather.pathTo(22577, 15609, 10);
 		Pather.makePortal();
 		say("1");
 
@@ -361,7 +361,7 @@ function main() {
 
 		Pather.useWaypoint(52);
 		Pather.moveToExit([51, 50], true);
-		Pather.moveTo(10022, 5047);
+		Pather.pathTo(10022, 5047);
 		say("a3");
 		Town.goToTown(3);
 		Town.doChores();
@@ -381,7 +381,7 @@ function main() {
 
 		var coords = [me.x, me.y];
 
-		Pather.moveTo(coords[0] + 23, coords[1] - 102);
+		Pather.pathTo(coords[0] + 23, coords[1] - 102);
 		Pather.makePortal();
 		Attack.securePosition(me.x, me.y, 40, 3000);
 		say("1");
@@ -390,9 +390,9 @@ function main() {
 			delay(250);
 		}
 
-		Pather.moveTo(coords[0] + 30, coords[1] - 134);
-		Pather.moveTo(coords[0] + 86, coords[1] - 130);
-		Pather.moveTo(coords[0] + 71, coords[1] - 94);
+		Pather.pathTo(coords[0] + 30, coords[1] - 134);
+		Pather.pathTo(coords[0] + 86, coords[1] - 130);
+		Pather.pathTo(coords[0] + 71, coords[1] - 94);
 		Attack.securePosition(me.x, me.y, 40, 3000);
 
 		/*Attack.kill(getLocaleString(2863));
@@ -400,7 +400,7 @@ function main() {
 		Attack.kill(getLocaleString(2860));*/
 
 		say("2");
-		Pather.moveTo(coords[0] + 23, coords[1] - 102);
+		Pather.pathTo(coords[0] + 23, coords[1] - 102);
 		Pather.usePortal(null, me.name);
 
 		return true;
@@ -415,7 +415,7 @@ function main() {
 		Pather.useWaypoint(101, true);
 		Precast.doPrecast(true);
 		Pather.moveToExit(102, true);
-		Pather.moveTo(17692, 8023);
+		Pather.pathTo(17692, 8023);
 		Pather.makePortal();
 		delay(2000);
 		say("1");
@@ -424,10 +424,10 @@ function main() {
 			delay(250);
 		}
 
-		Pather.moveTo(17591, 8070);
+		Pather.pathTo(17591, 8070);
 		Attack.kill(242);
 		Pickit.pickItems();
-		Pather.moveTo(17692, 8023);
+		Pather.pathTo(17692, 8023);
 		Pather.makePortal();
 		say("2");
 
@@ -435,7 +435,7 @@ function main() {
 			delay(250);
 		}
 
-		Pather.moveTo(17591, 8070);
+		Pather.pathTo(17591, 8070);
 		Attack.securePosition(me.x, me.y, 40, 3000);
 
 		hydra = getUnit(1, getLocaleString(3325));
@@ -449,7 +449,7 @@ function main() {
 		}
 
 		Pather.makePortal();
-		Pather.moveTo(17581, 8070);
+		Pather.pathTo(17581, 8070);
 		say("1");
 
 		while (!this.playerIn()) {
@@ -457,7 +457,7 @@ function main() {
 		}
 
 		say("a4");
-		//Pather.moveTo(17591, 8070);
+		//Pather.pathTo(17591, 8070);
 
 		while (!this.playersInAct(4)) {
 			delay(250);
@@ -537,7 +537,7 @@ function main() {
 
 				for (i = 0; i < positions.length; i += 1) {
 					if (Attack.validSpot(target.x + positions[i][0], target.y + positions[i][1])) { // check if we can move there
-						Pather.moveTo(target.x + positions[i][0], target.y + positions[i][1]);
+						Pather.pathTo(target.x + positions[i][0], target.y + positions[i][1]);
 						Skill.setSkill(Config.AttackSkill[2], 0);
 
 						for (n = 0; n < amount; n += 1) {
@@ -591,7 +591,7 @@ function main() {
 		Town.doChores();
 		Pather.useWaypoint(107, true);
 		Precast.doPrecast(true);
-		Pather.moveTo(7790, 5544);
+		Pather.pathTo(7790, 5544);
 		this.initLayout();
 
 		if (!this.openSeal(395) || !this.openSeal(396)) {
@@ -599,9 +599,9 @@ function main() {
 		}
 
 		if (this.vizLayout === 1) {
-			Pather.moveTo(7691, 5292);
+			Pather.pathTo(7691, 5292);
 		} else {
-			Pather.moveTo(7695, 5316);
+			Pather.pathTo(7695, 5316);
 		}
 
 		if (!this.getBoss(getLocaleString(2851))) {
@@ -613,9 +613,9 @@ function main() {
 		}
 
 		if (this.seisLayout === 1) {
-			Pather.moveTo(7771, 5196);
+			Pather.pathTo(7771, 5196);
 		} else {
-			Pather.moveTo(7798, 5186);
+			Pather.pathTo(7798, 5186);
 		}
 
 		if (!this.getBoss(getLocaleString(2852))) {
@@ -629,23 +629,23 @@ function main() {
 		if (this.infLayout === 1) {
 			delay(1);
 		} else {
-			Pather.moveTo(7928, 5295); // temp
+			Pather.pathTo(7928, 5295); // temp
 		}
 
 		if (!this.getBoss(getLocaleString(2853))) {
 			throw new Error("Failed to kill Infector");
 		}
 
-		Pather.moveTo(7763, 5267);
+		Pather.pathTo(7763, 5267);
 		Pather.makePortal();
-		Pather.moveTo(7727, 5267);
+		Pather.pathTo(7727, 5267);
 		say("1");
 
 		while (!this.playerIn()) {
 			delay(250);
 		}
 
-		Pather.moveTo(7763, 5267);
+		Pather.pathTo(7763, 5267);
 
 		while (!getUnit(1, 243)) {
 			delay(500);
@@ -700,7 +700,7 @@ function main() {
 			throw new Error("Failed to go to Ancients way.");
 		}
 
-		Pather.moveTo(10089, 12622);
+		Pather.pathTo(10089, 12622);
 		Pather.makePortal();
 		say("3");
 
@@ -708,7 +708,7 @@ function main() {
 			delay(250);
 		}
 
-		Pather.moveTo(10048, 12628);
+		Pather.pathTo(10048, 12628);
 
 		altar = getUnit(2, 546);
 
@@ -726,7 +726,7 @@ function main() {
 		}
 
 		Attack.clear(50);
-		Pather.moveTo(10089, 12622);
+		Pather.pathTo(10089, 12622);
 		me.cancel();
 		Pather.makePortal();
 
@@ -766,7 +766,7 @@ function main() {
 				}
 
 				if (getDistance(me, 15093, 5029) > 3) {
-					Pather.moveTo(15093, 5029);
+					Pather.pathTo(15093, 5029);
 				}
 
 				if (Config.AttackSkill[4] > 0) {
@@ -855,7 +855,7 @@ function main() {
 			}
 
 			for (i = 0; i < pos.length; i += 2) {
-				Pather.moveTo(pos[i], pos[i + 1]);
+				Pather.pathTo(pos[i], pos[i + 1]);
 				Attack.clear(30);
 			}
 		};
@@ -866,7 +866,7 @@ function main() {
 			if (hydra) {
 				do {
 					if (hydra.mode !== 12 && hydra.getStat(172) !== 2) {
-						Pather.moveTo(15118, 5002);
+						Pather.pathTo(15118, 5002);
 
 						while (hydra.mode !== 12) {
 							delay(500);
@@ -894,17 +894,17 @@ function main() {
 			}
 		}
 
-		Pather.moveTo(15113, 5040);
+		Pather.pathTo(15113, 5040);
 		Attack.clear(15);
 		this.clearThrone();
 
 		tick = getTickCount();
-		Pather.moveTo(15093, me.classid === 3 ? 5029 : 5039);
+		Pather.pathTo(15093, me.classid === 3 ? 5029 : 5039);
 
 MainLoop:
 		while (true) {
 			if (getDistance(me, 15093, me.classid === 3 ? 5029 : 5039) > 3) {
-				Pather.moveTo(15093, me.classid === 3 ? 5029 : 5039);
+				Pather.pathTo(15093, me.classid === 3 ? 5029 : 5039);
 			}
 
 			if (!getUnit(1, 543)) {
@@ -964,7 +964,7 @@ MainLoop:
 		}
 
 		this.clearThrone();
-		Pather.moveTo(15092, 5011);
+		Pather.pathTo(15092, 5011);
 		Precast.doPrecast(true);
 
 		while (getUnit(1, 543)) {
@@ -981,9 +981,9 @@ MainLoop:
 			throw new Error("Couldn't find portal.");
 		}
 
-		Pather.moveTo(15213, 5908);
+		Pather.pathTo(15213, 5908);
 		Pather.makePortal();
-		Pather.moveTo(15170, 5950);
+		Pather.pathTo(15170, 5950);
 		delay(1000);
 		say("3");
 
@@ -991,7 +991,7 @@ MainLoop:
 			delay(250);
 		}
 
-		Pather.moveTo(15134, 5923);
+		Pather.pathTo(15134, 5923);
 		Attack.kill(544); // Baal
 		Pickit.pickItems();
 
@@ -1255,7 +1255,7 @@ MainLoop:
 
 		Pather.useWaypoint(111, true);
 		Precast.doPrecast(false);
-		Pather.moveTo(3846, 5120);
+		Pather.pathTo(3846, 5120);
 		Attack.securePosition(me.x, me.y, 30, 3000);
 		Pather.makePortal();
 		say("1");
@@ -1266,7 +1266,7 @@ MainLoop:
 
 		Attack.kill(getLocaleString(22435)); // Shenk
 		Pickit.pickItems();
-		Pather.moveTo(3846, 5120);
+		Pather.pathTo(3846, 5120);
 		say("2");
 
 		while (this.playerIn()) {


### PR DESCRIPTION
Primary changes:
Pather.moveTo() changed to Pather.pathTo() to account for behavior changes.  PathTo() should be used when traveling long distances or when it's acceptable to open chests/shrines along the way.
Pather.maneuverTo() added to behave more closely to prior Pather.moveTo().  maneuverTo should be used if the bot should simply move from point A to B without opening chests/shrines (but clear monsters along the way if clearPath is set).  Small movements should be performed with maneuverTo()
Added Chest object in Misc.js, improved chest opening behavior to prevent thrashing