### PR TITLE
Add red portal use in Summoner + minor fix

### DIFF
--- a/d2bs/kolbot/libs/bots/Andariel.js
+++ b/d2bs/kolbot/libs/bots/Andariel.js
@@ -4,7 +4,7 @@
 *	@desc		kill Andariel
 */
 
-function Andariel() {
+function Andariel () {
 	this.killAndariel = function () {
 		var i,
 			target = getUnit(1, 156);
@@ -19,7 +19,7 @@ function Andariel() {
 		}
 
 		for (i = 0; i < 300; i += 1) {
-			ClassAttack.doCast(target, Config.AttackSkill[1], Config.AttackSkill[2]);
+			ClassAttack.doAttack(target);
 
 			if (target.dead) {
 				return true;

--- a/d2bs/kolbot/libs/bots/Andariel.js
+++ b/d2bs/kolbot/libs/bots/Andariel.js
@@ -4,7 +4,7 @@
 *	@desc		kill Andariel
 */
 
-function Andariel() {
+function Andariel () {
 	this.killAndariel = function () {
 		var i,
 			target = getUnit(1, 156);

--- a/d2bs/kolbot/libs/bots/Duriel.js
+++ b/d2bs/kolbot/libs/bots/Duriel.js
@@ -4,7 +4,7 @@
 *	@desc		kill Duriel
 */
 
-function Duriel() {
+function Duriel () {
 	this.killDuriel = function () {
 		var i, target;
 
@@ -42,11 +42,26 @@ function Duriel() {
 		return target.dead;
 	};
 
+	// return the script position in the list of scripts to be ran
+	this.scriptIndex = function (script) {
+		let s, charScripts = [];
+
+		for (s in Scripts) {
+			if (Scripts[s]) {
+				charScripts.push(s);
+			}
+		}
+
+		return charScripts.indexOf(script);
+	};
+
 	var i, unit;
 
-	Town.doChores();
-	Pather.useWaypoint(46);
-	Precast.doPrecast(true);
+	if (!Scripts.Summoner || this.scriptIndex("Duriel") !== this.scriptIndex("Summoner") + 1) {
+		Town.doChores();
+		Pather.useWaypoint(46);
+		Precast.doPrecast(true);
+	}
 
 	if (!Pather.moveToExit(getRoom().correcttomb, true)) {
 		throw new Error("Failed to move to Tal Rasha's Tomb");

--- a/d2bs/kolbot/libs/bots/Duriel.js
+++ b/d2bs/kolbot/libs/bots/Duriel.js
@@ -28,7 +28,7 @@ function Duriel () {
 		}
 
 		for (i = 0; i < 300; i += 1) {
-			ClassAttack.doCast(target, Config.AttackSkill[1], Config.AttackSkill[2]);
+			ClassAttack.doAttack(target);
 
 			if (target.dead) {
 				return true;

--- a/d2bs/kolbot/libs/bots/Duriel.js
+++ b/d2bs/kolbot/libs/bots/Duriel.js
@@ -4,7 +4,7 @@
 *	@desc		kill Duriel
 */
 
-function Duriel() {
+function Duriel () {
 	this.killDuriel = function () {
 		var i, target;
 

--- a/d2bs/kolbot/libs/bots/Duriel.js
+++ b/d2bs/kolbot/libs/bots/Duriel.js
@@ -47,8 +47,9 @@ function Duriel() {
 	if (me.area !== 46) {
 		Town.doChores();
 		Pather.useWaypoint(46);
-		Precast.doPrecast(true);
 	}
+
+	Precast.doPrecast(true);
 
 	if (!Pather.moveToExit(getRoom().correcttomb, true)) {
 		throw new Error("Failed to move to Tal Rasha's Tomb");

--- a/d2bs/kolbot/libs/bots/Summoner.js
+++ b/d2bs/kolbot/libs/bots/Summoner.js
@@ -4,7 +4,20 @@
 *	@desc		kill the Summoner
 */
 
-function Summoner() {
+function Summoner () {
+	// return the script position in the list of scripts to be ran
+	this.scriptIndex = function (script) {
+		let s, charScripts = [];
+
+		for (s in Scripts) {
+			if (Scripts[s]) {
+				charScripts.push(s);
+			}
+		}
+
+		return charScripts.indexOf(script);
+	};
+
 	Town.doChores();
 	Pather.useWaypoint(74);
 	Precast.doPrecast(true);
@@ -26,6 +39,23 @@ function Summoner() {
 	}
 
 	Attack.clear(15, 0, 250); // The Summoner
+
+	if (Scripts.Duriel && this.scriptIndex("Duriel") === this.scriptIndex("Summoner") + 1) {
+		let journal = getUnit(2, 357);
+
+		if (!journal) {
+			throw new Error("Journal not found");
+		}
+
+		Pather.moveTo(journal.x, journal.y);
+		journal.interact();
+		delay(500);
+		me.cancel();
+
+		if (!Pather.usePortal(46)) {
+			throw new Error("Failed to take arcane portal");
+		}
+	}
 
 	return true;
 }

--- a/d2bs/kolbot/libs/bots/Summoner.js
+++ b/d2bs/kolbot/libs/bots/Summoner.js
@@ -4,7 +4,7 @@
 *	@desc		kill the Summoner
 */
 
-function Summoner() {
+function Summoner () {
 	Town.doChores();
 	Pather.useWaypoint(74);
 	Precast.doPrecast(true);
@@ -42,6 +42,8 @@ function Summoner() {
 		if (!Pather.usePortal(46)) {
 			throw new Error("Failed to take arcane portal");
 		}
+
+		Loader.skipTown.push("Duriel");
 	}
 
 	return true;

--- a/d2bs/kolbot/libs/common/Loader.js
+++ b/d2bs/kolbot/libs/common/Loader.js
@@ -149,10 +149,10 @@ var Loader = {
 	scriptName: function (offset = 0) {
 		let index = this.scriptIndex + offset;
 
-		if (index < 0 || index >= this.scriptList.length) {
-			return undefined;
+		if (index >= 0 && index < this.scriptList.length) {
+			return this.scriptList[index];
 		}
 
-		return this.scriptList[index];
+		return null;
 	}
 };

--- a/d2bs/kolbot/libs/common/Loader.js
+++ b/d2bs/kolbot/libs/common/Loader.js
@@ -105,7 +105,7 @@ var Loader = {
 								reconfiguration = typeof Scripts[i] === 'object';
 
 								if (typeof (global[i]) === "function") {
-									if (i !== "Test" && i !== "Follower") {
+									if (i !== "Test" && i !== "Follower" && i !== "Duriel") {
 										townCheck = Town.goToTown();
 									} else {
 										townCheck = true;

--- a/d2bs/kolbot/libs/common/Loader.js
+++ b/d2bs/kolbot/libs/common/Loader.js
@@ -9,6 +9,7 @@ var global = this;
 var Loader = {
 	scriptList: [],
 	scriptIndex: -1,
+	skipTown: ["Test", "Follower"],
 
 	init: function () {
 		this.getScripts();
@@ -106,10 +107,10 @@ var Loader = {
 								reconfiguration = typeof Scripts[i] === 'object';
 
 								if (typeof (global[i]) === "function") {
-									if (i !== "Test" && i !== "Follower" && i !== "Duriel") {
-										townCheck = Town.goToTown();
-									} else {
+									if (this.skipTown.indexOf(i) > -1) {
 										townCheck = true;
+									} else {
+										townCheck = Town.goToTown();
 									}
 
 									if (townCheck) {

--- a/d2bs/kolbot/libs/common/Pather.js
+++ b/d2bs/kolbot/libs/common/Pather.js
@@ -895,6 +895,14 @@ ModeLoop:
 			}
 
 			if (me.inTown) {
+				if (me.area === 40 && me.x === 5153 && me.y === 5203) {
+					let npc = getUnit(1, "warriv");
+
+					if (npc && npc.openMenu()) {
+						Misc.useMenu(0x0D37);
+					}
+				}
+
 				Town.move("waypoint");
 			}
 

--- a/d2bs/kolbot/libs/common/Pather.js
+++ b/d2bs/kolbot/libs/common/Pather.js
@@ -895,6 +895,8 @@ ModeLoop:
 			}
 
 			if (me.inTown) {
+				npc = getUnit(1, NPC.Warriv);
+
 				if (me.area === 40 && npc && getDistance(me, npc) < 50) {
 					if (npc && npc.openMenu()) {
 						Misc.useMenu(0x0D37);

--- a/d2bs/kolbot/libs/common/Town.js
+++ b/d2bs/kolbot/libs/common/Town.js
@@ -69,6 +69,12 @@ var Town = {
 	doChores: function () {
 		if (!me.inTown) {
 			this.goToTown();
+		} else if (me.area === 40 && me.x === 5153 && me.y === 5203) {
+			let npc = getUnit(1, "warriv");
+
+			if (npc && npc.openMenu()) {
+				Misc.useMenu(0x0D37);
+			}
 		}
 
 		var i,

--- a/d2bs/kolbot/libs/common/Town.js
+++ b/d2bs/kolbot/libs/common/Town.js
@@ -67,17 +67,12 @@ var Town = {
 
 	// Do town chores
 	doChores: function (repair = false) {
-		var i,
-			cancelFlags = [0x01, 0x02, 0x04, 0x08, 0x14, 0x16, 0x0c, 0x0f, 0x19, 0x1a],
-			npc = getUnit(1, "warriv");
-
 		if (!me.inTown) {
 			this.goToTown();
-		} else if (me.area === 40 && npc && getDistance(me, npc) < 50) {
-			if (npc.openMenu()) {
-				Misc.useMenu(0x0D37);
-			}
 		}
+
+		var i,
+			cancelFlags = [0x01, 0x02, 0x04, 0x08, 0x14, 0x16, 0x0c, 0x0f, 0x19, 0x1a];
 
 		Attack.weaponSwitch(Attack.getPrimarySlot());
 


### PR DESCRIPTION
Summoner.js, Duriel.js, Loader.js
- If Duriel script is run after Summoner, use red portal instead of going to town

Andariel.js, Duriel.js
- Fix a classic issue with ClassAttack.doCast, c.f. https://blizzhackers.discourse.group/t/sorc-wont-static-duriel/116/

Town.js, Pather.js
- If bot starts in act2, use Warriv to go to act 1 instead of walking across Lut Gholein. Implemented in useWaypoint and doChores