### PR TITLE
Mercenary

### DIFF
--- a/d2bs/kolbot/default.dbj
+++ b/d2bs/kolbot/default.dbj
@@ -22,6 +22,7 @@ include("common/Precast.js");
 include("common/Prototypes.js");
 include("common/Runewords.js");
 include("common/Storage.js");
+include("common/Mercenary.js");
 include("common/Town.js");
 
 function main() {

--- a/d2bs/kolbot/libs/GameAction.js
+++ b/d2bs/kolbot/libs/GameAction.js
@@ -494,7 +494,7 @@ var GameAction = {
 
 		if (this.LogMerc) {
 			for (i = 0; i < 3; i += 1) {
-				merc = me.getMerc();
+				merc = Mercenary.getMerc();
 
 				if (merc) {
 					break;

--- a/d2bs/kolbot/libs/MuleLogger.js
+++ b/d2bs/kolbot/libs/MuleLogger.js
@@ -373,7 +373,7 @@ var MuleLogger = {
 
 		if (this.LogMerc) {
 			for (i = 0; i < 3; i += 1) {
-				merc = me.getMerc();
+				merc = Mercenary.getMerc();
 
 				if (merc) {
 					break;

--- a/d2bs/kolbot/libs/common/Attack.js
+++ b/d2bs/kolbot/libs/common/Attack.js
@@ -164,7 +164,7 @@ var Attack = {
 		var i, merc, item;
 
 		for (i = 0; i < 3; i += 1) {
-			merc = me.getMerc();
+			merc = Mercenary.getMerc();
 
 			if (merc) {
 				break;

--- a/d2bs/kolbot/libs/common/Mercenary.js
+++ b/d2bs/kolbot/libs/common/Mercenary.js
@@ -1,0 +1,401 @@
+
+var Mercenary = {
+	variants: {
+		"271": [7, 11],
+		"338": [[99, 104, 108], [103, 114, 98]],	//Normal/Hell, Nightmare
+		"359": [41, 55, 38],
+		"560": [126]
+	},
+	
+	classIds: [
+		-1,		
+		271, 	//Act 1 - Rogue
+		338,	//Act 2 - Guard
+		359,	//Act 3 - Iron Wolf
+		-1,
+		560		//Act 5 - Barb
+	],
+	
+	availableMercs: [],
+	
+	getMerc: function() {
+		if (!Config.UseMerc)
+			return null;
+		
+		var merc = null;
+		
+		// me.getMerc() might return null if called right after taking a portal, that's why there's retry attempts
+		for (var i = 0; i < 3; i++) {
+			merc = me.getMerc();
+
+			if (merc && merc.mode === 0 && merc.mode === 12) {
+				return null;
+			}
+			else if (merc)
+				break;
+
+			delay(100);
+			
+		}
+				
+		return merc;
+		
+	},
+	
+	getVariant: function() {
+		var merc = this.getMerc();
+		if (!merc)
+			return null;
+		
+		for (var i = 0; i < this.variants[merc.classid].length; i++) {
+			if (Array.isArray(this.variants[merc.classid][i])) {
+				for (var j = 0; j < this.variants[merc.classid][i].length; j++) {
+					if (merc.getSkill(this.variants[merc.classid][i][j], 1))
+						return this.variants[merc.classid][i][j];
+				}
+			} else {			
+				if (merc.getSkill(this.variants[merc.classid][i], 1))
+					return this.variants[merc.classid][i];
+				
+			}
+			
+		}
+		
+		throw new Error("Mercenary.getVariant: Couldn't determine merc variant.");
+		
+	},
+	
+	hasMerc: function(mercType, variant) {
+		if (!Config.UseMerc)
+			return false;	//We don't want a merc
+		if (mercType === undefined) {
+			if (typeof Config.UseMerc === "object")
+				mercType = Config.UseMerc.mercType;
+			else
+				mercType = Config.UseMerc;
+
+		}
+		if (variant === undefined) {
+			if (typeof Config.UseMerc === "object")
+				variant = Config.UseMerc.variant;
+			else
+				variant = -1;
+			
+		}
+		if (mercType < 1 || mercType > 5 || mercType === 4)
+			throw new Error("Mercenary.hasMerc: Incorrect value for mercType");
+		
+		var merc = this.getMerc();
+		if (!merc && (me.mercrevivecost === 0 || me.gametype === 0))
+			return false;	//We never had a merc
+		else if (this.isDead())
+			return true;	//Merc is dead so we can't determine the variant or type
+		else if (this.classIds[mercType] !== merc.classid) {
+			return false;	//We want a different type of merc
+			
+		}
+		
+		//If the variant was specified, determine if the merc variant is the same
+		if (variant !== -1) {
+			if (this.getVariant() !== variant) {
+				return false;	//We want a different variant of merc
+				
+			}
+			
+		}
+		
+		return true;
+		
+	},
+	
+	isDead: function() {
+		return Config.UseMerc && me.mercrevivecost > 0;
+		
+	},
+	
+	needMerc: function () {
+		if (me.gold < me.mercrevivecost)
+			return false;
+		
+		return Config.UseMerc;
+
+	},
+	
+	canHire: function(mercType) {
+		if (mercType === undefined) {
+			if (typeof Config.UseMerc === "object")
+				mercType = Config.UseMerc.mercType;
+			else
+				mercType = Config.UseMerc;
+			
+		}
+		
+		var canHire = false;
+		
+		switch (mercType) {
+			case 1:
+				if ((this._checkQuest(2, 1) || this._checkQuest(2, 0)) && me.charlvl >= 8)
+					canHire = true;
+			break;
+			
+			case 2:
+				if (me.getQuest(6, 0) || me.getQuest(6, 1))
+					canHire = true;
+			break;
+			
+			case 3:
+				if (me.getQuest(14, 0) || me.getQuest(14, 1) || me.getQuest(14, 3) || me.getQuest(14, 4))
+					canHire = true;
+			break;
+			
+			case 5:
+				if (me.getQuest(36, 0))
+					canHire = true;
+			break;
+			
+			default:
+				throw new Error("Mercenary.canHire: Incorrect value for mercType: " + mercType);
+			
+		}
+		
+		return canHire;
+		
+	},
+	
+	hire: function (args) {	
+		if (args === undefined)
+			return false;
+		if (args.mercType === undefined)
+			throw new Error("Mercenary.hire: args.mercType is required");
+		if (args.mercType < 1 || args.mercType === 4 || args.mercType > 5)
+			throw new Error("Mercenary.hire: Invalid mercType");
+		if (args.replace === undefined)
+			args.replace = false;	//useful if the merc level is far behind our level and we want a new one to catch up
+		if (args.variant === undefined)
+			args.variant = -1;
+		
+		if (!args.replace && this.hasMerc(args.mercType, args.variant))
+			return true;
+		
+		if (!this.canHire(args.mercType)) {
+			print("Mercenary.hire:  Can't hire merc of type " + args.mercType);
+			return false;
+			
+		}
+		
+		print("Mercenary.hire: Hiring new Merc of type " + args.mercType + " and variant " + args.variant);
+		
+		if (!Town.goToTown(args.mercType))
+			return false;
+
+		if (this.isDead())
+			this.revive();	//Revive so we can pull the equipment off, just in case
+		
+		if (!this.unloadEquipment())
+			return false;	//Bail out if we can't unload the merc's equipment, just in case
+		
+		Town.move(Town.tasks[args.mercType - 1]["Merc"]);	//Move to Merc NPC for the mercType act
+		Pather.pathTo(me.x + rand(-3, 3), me.y + rand(-3, 3));
+		Town.move(Town.tasks[args.mercType - 1]["Merc"]);
+		
+		delay(1000);
+		
+		addEventListener("gamepacket", this._gamePacket);
+		var hire = getUnit(1, Town.tasks[args.mercType - 1]["Merc"]);
+		if (!hire || !hire.openMenu()) {
+			sendPacket(1, 0x4b, 4, me.type, 4, me.gid);
+			delay(1000 + me.ping);
+			Town.move(Town.tasks[args.mercType - 1]["Merc"]);
+			sendPacket(1, 0x4b, 4, me.type, 4, me.gid);
+			hire = getUnit(1, Town.tasks[args.mercType - 1]["Merc"]);
+			hire.openMenu();
+			if (!hire || !hire.openMenu()) {
+				throw new Error("Mercenary.hireMerc: failed to open npc menu");
+			}
+		}
+		
+		delay(1000 + me.ping * 2);
+		
+		removeEventListener("gamepacket", this._gamePacket);
+		
+		//Hire mercs until we get the right one.
+		if (Mercenary.availableMercs.length) {
+			do {
+				print("Trying to hire a merc");
+				//print(Mercenary.availableMercs.toSource());
+				Misc.useMenu(0x0D45);
+				sendPacket(1, 0x36, 4, hire.gid, 4, Mercenary.availableMercs.pop());
+				
+				delay(2000 + me.ping * 2);
+				
+				var v = this.getVariant();
+				print("my new merc variant is: " + v + " - desired variant: " + args.variant);
+				if (args.variant === v)
+					break;
+			
+			} while(!this.hasMerc(args.mercType, args.variant) && Mercenary.availableMercs.length > 0);
+		
+		} else {
+			print("No mercs available");
+			
+			me.cancel();
+			
+			return false;
+			
+		} 
+		
+		me.cancel();
+	
+		return true;
+		
+    },
+	
+	revive: function() {
+		if (!this.needMerc()) {
+			print("I don't need to revive my merc");
+			return true;
+		}
+		
+		if (!this.isDead())
+			return true;
+
+		// Fuck Aheara
+		if (me.act === 3) {
+			Town.goToTown(2);
+		}
+
+		var i, tick, dialog, lines,
+			preArea = me.area,
+			npc = Town.initNPC("Merc", "reviveMerc");
+
+		if (!npc) {
+			return false;
+		}
+
+MainLoop:
+		for (i = 0; i < 3; i += 1) {
+			dialog = getDialogLines();
+
+			for (lines = 0; lines < dialog.length; lines += 1) {
+				if (dialog[lines].text.match(":", "gi")) {
+					dialog[lines].handler();
+					delay(Math.max(750, me.ping * 2));
+				}
+
+				// "You do not have enough gold for that."
+				if (dialog[lines].text.match(getLocaleString(3362), "gi")) {
+					return false;
+				}
+			}
+
+			while (getTickCount() - tick < 2000) {
+				if (!!me.getMerc()) {
+					delay(Math.max(750, me.ping * 2));
+
+					break MainLoop;
+				}
+
+				delay(200);
+			}
+		}
+
+		Attack.checkInfinity();
+
+		if (!!me.getMerc()) {
+			if (Config.MercWatch && !me.inTown) { // Cast BO on merc so he doesn't just die again
+				print("MercWatch precast");
+				Pather.useWaypoint("random");
+				Precast.doPrecast(true);
+				Pather.useWaypoint(preArea);
+			}
+
+			return true;
+		}
+
+		return false;
+		
+	},
+	
+	unloadEquipment: function() {
+		print("Unloading merc equipment");
+		
+		//ok this is a bit stupid
+		clickItem(4, 4);
+		delay(me.ping + 500);
+		if (me.itemoncursor) {
+			delay(me.ping + 500);
+			cursorItem = getUnit(100);
+			if (cursorItem) {
+				if (!Storage.Inventory.MoveTo(cursorItem))
+					return false;
+				
+				delay(me.ping + 1000);
+				if (me.itemoncursor) {
+					Misc.click(0, 0, me);
+					delay(me.ping + 500);
+				}
+			}
+		}
+		
+		clickItem(4, 3);
+		delay(me.ping + 500);
+		if (me.itemoncursor) {
+			delay(me.ping + 500);
+			cursorItem = getUnit(100);
+			if (cursorItem) {
+				if (!Storage.Inventory.MoveTo(cursorItem))
+					return false;
+				
+				delay(me.ping + 1000);
+				if (me.itemoncursor) {
+					Misc.click(0, 0, me);
+					delay(me.ping + 500);
+				}
+
+			}
+
+		}
+		
+		clickItem(4, 1);
+		delay(me.ping + 500);
+		if (me.itemoncursor) {
+			delay(me.ping + 500);
+			cursorItem = getUnit(100);
+			if (cursorItem) {
+				if (!Storage.Inventory.MoveTo(cursorItem))
+					return false;
+				
+				delay(me.ping + 500);
+				if (me.itemoncursor) {
+					Misc.click(0, 0, me);
+					delay(me.ping + 500);
+				}
+			}
+		}
+			
+		return true;
+		
+	},
+	
+	_gamePacket: function (bytes) {
+        switch (bytes[0]) {
+            case 0x4e:
+				//print("bytes " + bytes.toSource());
+                var id = (bytes[2] << 8) + bytes[1];
+                if (Mercenary.availableMercs.indexOf(id) !== -1) {
+					//print("length = 0");
+                    Mercenary.availableMercs.length = 0;
+                }
+                Mercenary.availableMercs.push(id);
+                break;
+        }
+    },
+	
+	_checkQuest: function (id, state) {
+		sendPacket(1, 0x40);
+		delay(500);
+
+		return me.getQuest(id, state);
+	}
+		
+};

--- a/d2bs/kolbot/libs/common/Misc.js
+++ b/d2bs/kolbot/libs/common/Misc.js
@@ -483,6 +483,10 @@ var Item = {
 		return Config.AutoEquip && NTIP.GetTier(item) > 0;
 	},
 
+	hasMercTier: function (item) {
+        return Config.AutoEquip && NTIP.GetMercTier(item) > 0;
+    },
+	
 	canEquip: function (item) {
 		if (item.type !== 4) { // Not an item
 			return false;
@@ -493,11 +497,33 @@ var Item = {
 		}
 
 		if (item.getStat(92) > me.getStat(12) || item.dexreq > me.getStat(2) || item.strreq > me.getStat(0)) { // Higher requirements
+			print("Can't equip " + item.name);
 			return false;
 		}
 
 		return true;
 	},
+	
+	canEquipMerc: function (item, bodyLoc) {  
+        if (!Mercenary.hasMerc()) { // dont have merc or he is dead
+            return false;
+        }
+          if (item.type !== 4) { // Not an item
+            return false;
+        }
+        if (!item.getFlag(0x10)) { // Unid item
+            return false;
+        }
+        
+        var merc = Mercenary.getMerc();
+        var curr = this.getEquippedItemMerc(bodyLoc);
+ 
+        if (item.getStat(92) > merc.getStat(12) || item.dexreq > merc.getStat(2) - curr.dex || item.strreq > merc.getStat(0)) { // Higher requirements
+            return false;
+        }
+ 
+        return true;
+    },
 
 	// Equips an item and throws away the old equipped item
 	equip: function (item, bodyLoc) {
@@ -543,6 +569,50 @@ var Item = {
 
 		return false;
 	},
+	
+	equipMerc: function (item, bodyLoc) {
+        if (!this.canEquipMerc(item, bodyLoc)) {
+            return false;
+        }
+ 
+        // Already equipped in the right slot
+        if (item.mode === 1 && item.bodylocation === bodyLoc) {
+            return true;
+        }
+ 
+        var i, cursorItem;
+ 
+        if (item.location === 7) {
+            if (!Town.openStash()) {
+                return false;
+            }
+        }
+ 
+        for (i = 0; i < 3; i += 1) {
+            if (item.toCursor()) {
+                var gid = item.gid;
+                clickItem(4, bodyLoc);
+                delay(me.ping * 2 + 500);
+ 
+                if (item.bodylocation === bodyLoc) {
+        
+                    if (getCursorType() === 3) {
+ 
+                        cursorItem = getUnit(100);
+ 
+                        if (cursorItem && Pickit.checkItem(cursorItem).result > 0) {
+                            if (Storage.Inventory.CanFit(cursorItem)) {
+                                Storage.Inventory.MoveTo(cursorItem);
+                            }
+                        }
+                    }
+                    return true;
+                }
+            }
+        }
+ 
+        return false;
+    },
 
 	getEquippedItem: function (bodyLoc) {
 		var item = me.getItem();
@@ -565,6 +635,35 @@ var Item = {
 		};
 	},
 
+	 getEquippedItemMerc: function (bodyLoc) {
+        var merc = Mercenary.getMerc();
+        var item = merc.getItem();
+ 
+        if (item) {
+            do {
+                if (item.bodylocation === bodyLoc && item.location === 1) {
+                    //print("Current Merc item tier: " + NTIP.GetMercTier(item) + " (" + item.name + ")");
+                    return {
+                        classid: item.classid,
+                        tier: NTIP.GetMercTier(item),
+                        name: item.name,
+                        str: item.getStatEx(0),
+                        dex: item.getStatEx(2)
+                    };
+                }
+            } while (item.getNext());
+        }
+ 
+        // Don't have anything equipped in there
+        return {
+            classid: -1,
+            tier: -1,
+            name: "none",
+            str: 0,
+            dex: 0
+        };
+    },
+	
 	getBodyLoc: function (item) {
 		var bodyLoc;
 
@@ -647,6 +746,42 @@ var Item = {
 		return bodyLoc;
 	},
 
+	 getBodyLocMerc: function (item) {
+        var bodyLocMerc;
+ 
+        switch (item.itemType) {
+        case 2: // Shield
+            bodyLocMerc = 5;
+ 
+            break;
+        case 3: // Armor
+            bodyLocMerc = 3;
+ 
+            break;
+            
+        case 37: // Helm
+        case 75: // Circlet
+            bodyLocMerc = 1;
+ 
+            break;
+        case 27: //
+        case 30: //
+        case 33: //
+        case 34: //
+            bodyLocMerc = 4;
+ 
+            break;
+        default:
+            return false;
+        }
+ 
+        if (typeof bodyLocMerc === "number") {
+            bodyLocMerc = [bodyLocMerc];
+        }
+ 
+        return bodyLocMerc;
+    },
+	
 	autoEquipCheck: function (item) {
 		if (!Config.AutoEquip) {
 			return true;
@@ -662,6 +797,8 @@ var Item = {
 				if (tier > this.getEquippedItem(bodyLoc[i]).tier && (this.canEquip(item) || !item.getFlag(0x10))) {
 					return true;
 				}
+				else if (item.getFlag(0x10))
+					print("Should not autoequip tier " + tier + " " + item.name + " - my tier " + this.getEquippedItem(bodyLoc[i]).tier);
 			}
 		}
 
@@ -672,6 +809,40 @@ var Item = {
 
 		return true;
 	},
+	
+	autoEquipCheckMerc: function (item) {
+        if (!Config.AutoEquip) {
+            return true;
+        }
+        
+        if (Config.AutoEquip && !Mercenary.hasMerc()) {
+            return false;
+        }
+ 
+        var i,
+            tier = NTIP.GetMercTier(item),
+            color = Pickit.itemColor(item),
+            bodyLoc = this.getBodyLocMerc(item);
+        
+        if (tier > 0 && bodyLoc) {
+            for (i = 0; i < bodyLoc.length; i += 1) {
+                // Low tier items shouldn't be kept if they can't be equipped
+                var oldTier = this.getEquippedItemMerc(bodyLoc[i]).tier;
+                if (tier > oldTier && (this.canEquipMerc(item) || !item.getFlag(0x10))) {
+                    //print("\xFFc8AutoPlay \xFFc0:: New merc item: " + color + item.name + " \xFFc0(new: " + tier + ", old: " + oldTier + ")");
+					return true;
+                }
+
+            }
+        }
+
+		if (tier > 0 && tier < 100) {
+			return false;
+		}
+		
+        return true;
+		
+    },
 
 	// returns true if the item should be kept+logged, false if not
 	autoEquip: function () {

--- a/d2bs/kolbot/libs/common/Misc.js
+++ b/d2bs/kolbot/libs/common/Misc.js
@@ -483,10 +483,6 @@ var Item = {
 		return Config.AutoEquip && NTIP.GetTier(item) > 0;
 	},
 
-	hasMercTier: function (item) {
-        return Config.AutoEquip && NTIP.GetMercTier(item) > 0;
-    },
-	
 	canEquip: function (item) {
 		if (item.type !== 4) { // Not an item
 			return false;
@@ -497,33 +493,11 @@ var Item = {
 		}
 
 		if (item.getStat(92) > me.getStat(12) || item.dexreq > me.getStat(2) || item.strreq > me.getStat(0)) { // Higher requirements
-			print("Can't equip " + item.name);
 			return false;
 		}
 
 		return true;
 	},
-	
-	canEquipMerc: function (item, bodyLoc) {  
-        if (!Mercenary.hasMerc()) { // dont have merc or he is dead
-            return false;
-        }
-          if (item.type !== 4) { // Not an item
-            return false;
-        }
-        if (!item.getFlag(0x10)) { // Unid item
-            return false;
-        }
-        
-        var merc = Mercenary.getMerc();
-        var curr = this.getEquippedItemMerc(bodyLoc);
- 
-        if (item.getStat(92) > merc.getStat(12) || item.dexreq > merc.getStat(2) - curr.dex || item.strreq > merc.getStat(0)) { // Higher requirements
-            return false;
-        }
- 
-        return true;
-    },
 
 	// Equips an item and throws away the old equipped item
 	equip: function (item, bodyLoc) {
@@ -569,50 +543,6 @@ var Item = {
 
 		return false;
 	},
-	
-	equipMerc: function (item, bodyLoc) {
-        if (!this.canEquipMerc(item, bodyLoc)) {
-            return false;
-        }
- 
-        // Already equipped in the right slot
-        if (item.mode === 1 && item.bodylocation === bodyLoc) {
-            return true;
-        }
- 
-        var i, cursorItem;
- 
-        if (item.location === 7) {
-            if (!Town.openStash()) {
-                return false;
-            }
-        }
- 
-        for (i = 0; i < 3; i += 1) {
-            if (item.toCursor()) {
-                var gid = item.gid;
-                clickItem(4, bodyLoc);
-                delay(me.ping * 2 + 500);
- 
-                if (item.bodylocation === bodyLoc) {
-        
-                    if (getCursorType() === 3) {
- 
-                        cursorItem = getUnit(100);
- 
-                        if (cursorItem && Pickit.checkItem(cursorItem).result > 0) {
-                            if (Storage.Inventory.CanFit(cursorItem)) {
-                                Storage.Inventory.MoveTo(cursorItem);
-                            }
-                        }
-                    }
-                    return true;
-                }
-            }
-        }
- 
-        return false;
-    },
 
 	getEquippedItem: function (bodyLoc) {
 		var item = me.getItem();
@@ -635,35 +565,6 @@ var Item = {
 		};
 	},
 
-	 getEquippedItemMerc: function (bodyLoc) {
-        var merc = Mercenary.getMerc();
-        var item = merc.getItem();
- 
-        if (item) {
-            do {
-                if (item.bodylocation === bodyLoc && item.location === 1) {
-                    //print("Current Merc item tier: " + NTIP.GetMercTier(item) + " (" + item.name + ")");
-                    return {
-                        classid: item.classid,
-                        tier: NTIP.GetMercTier(item),
-                        name: item.name,
-                        str: item.getStatEx(0),
-                        dex: item.getStatEx(2)
-                    };
-                }
-            } while (item.getNext());
-        }
- 
-        // Don't have anything equipped in there
-        return {
-            classid: -1,
-            tier: -1,
-            name: "none",
-            str: 0,
-            dex: 0
-        };
-    },
-	
 	getBodyLoc: function (item) {
 		var bodyLoc;
 
@@ -746,42 +647,6 @@ var Item = {
 		return bodyLoc;
 	},
 
-	 getBodyLocMerc: function (item) {
-        var bodyLocMerc;
- 
-        switch (item.itemType) {
-        case 2: // Shield
-            bodyLocMerc = 5;
- 
-            break;
-        case 3: // Armor
-            bodyLocMerc = 3;
- 
-            break;
-            
-        case 37: // Helm
-        case 75: // Circlet
-            bodyLocMerc = 1;
- 
-            break;
-        case 27: //
-        case 30: //
-        case 33: //
-        case 34: //
-            bodyLocMerc = 4;
- 
-            break;
-        default:
-            return false;
-        }
- 
-        if (typeof bodyLocMerc === "number") {
-            bodyLocMerc = [bodyLocMerc];
-        }
- 
-        return bodyLocMerc;
-    },
-	
 	autoEquipCheck: function (item) {
 		if (!Config.AutoEquip) {
 			return true;
@@ -797,8 +662,6 @@ var Item = {
 				if (tier > this.getEquippedItem(bodyLoc[i]).tier && (this.canEquip(item) || !item.getFlag(0x10))) {
 					return true;
 				}
-				else if (item.getFlag(0x10))
-					print("Should not autoequip tier " + tier + " " + item.name + " - my tier " + this.getEquippedItem(bodyLoc[i]).tier);
 			}
 		}
 
@@ -809,40 +672,6 @@ var Item = {
 
 		return true;
 	},
-	
-	autoEquipCheckMerc: function (item) {
-        if (!Config.AutoEquip) {
-            return true;
-        }
-        
-        if (Config.AutoEquip && !Mercenary.hasMerc()) {
-            return false;
-        }
- 
-        var i,
-            tier = NTIP.GetMercTier(item),
-            color = Pickit.itemColor(item),
-            bodyLoc = this.getBodyLocMerc(item);
-        
-        if (tier > 0 && bodyLoc) {
-            for (i = 0; i < bodyLoc.length; i += 1) {
-                // Low tier items shouldn't be kept if they can't be equipped
-                var oldTier = this.getEquippedItemMerc(bodyLoc[i]).tier;
-                if (tier > oldTier && (this.canEquipMerc(item) || !item.getFlag(0x10))) {
-                    //print("\xFFc8AutoPlay \xFFc0:: New merc item: " + color + item.name + " \xFFc0(new: " + tier + ", old: " + oldTier + ")");
-					return true;
-                }
-
-            }
-        }
-
-		if (tier > 0 && tier < 100) {
-			return false;
-		}
-		
-        return true;
-		
-    },
 
 	// returns true if the item should be kept+logged, false if not
 	autoEquip: function () {

--- a/d2bs/kolbot/libs/common/Town.js
+++ b/d2bs/kolbot/libs/common/Town.js
@@ -77,6 +77,8 @@ var Town = {
 		Attack.weaponSwitch(Attack.getPrimarySlot());
 
 		this.heal();
+		Mercenary.revive();
+		Mercenary.hire(Config.UseMerc);
 		this.identify();
 		this.shopItems();
 		this.fillTome(518);
@@ -91,7 +93,6 @@ var Town = {
 		this.buyKeys();
 		this.repair();
 		this.gamble();
-		this.reviveMerc();
 		Cubing.doCubing();
 		Runewords.makeRunewords();
 		this.stash(true);
@@ -1412,92 +1413,6 @@ CursorLoop:
 		}
 
 		return itemList;
-	},
-
-	reviveMerc: function () {
-		if (!this.needMerc()) {
-			return true;
-		}
-
-		// Fuck Aheara
-		if (me.act === 3) {
-			this.goToTown(2);
-		}
-
-		var i, tick, dialog, lines,
-			preArea = me.area,
-			npc = this.initNPC("Merc", "reviveMerc");
-
-		if (!npc) {
-			return false;
-		}
-
-MainLoop:
-		for (i = 0; i < 3; i += 1) {
-			dialog = getDialogLines();
-
-			for (lines = 0; lines < dialog.length; lines += 1) {
-				if (dialog[lines].text.match(":", "gi")) {
-					dialog[lines].handler();
-					delay(Math.max(750, me.ping * 2));
-				}
-
-				// "You do not have enough gold for that."
-				if (dialog[lines].text.match(getLocaleString(3362), "gi")) {
-					return false;
-				}
-			}
-
-			while (getTickCount() - tick < 2000) {
-				if (!!me.getMerc()) {
-					delay(Math.max(750, me.ping * 2));
-
-					break MainLoop;
-				}
-
-				delay(200);
-			}
-		}
-
-		Attack.checkInfinity();
-
-		if (!!me.getMerc()) {
-			if (Config.MercWatch) { // Cast BO on merc so he doesn't just die again
-				print("MercWatch precast");
-				Pather.useWaypoint("random");
-				Precast.doPrecast(true);
-				Pather.useWaypoint(preArea);
-			}
-
-			return true;
-		}
-
-		return false;
-	},
-
-	needMerc: function () {
-		var i, merc;
-
-		if (me.gametype === 0 || !Config.UseMerc || me.gold < me.mercrevivecost) { // gametype 0 = classic
-			return false;
-		}
-
-		// me.getMerc() might return null if called right after taking a portal, that's why there's retry attempts
-		for (i = 0; i < 3; i += 1) {
-			merc = me.getMerc();
-
-			if (merc && merc.mode !== 0 && merc.mode !== 12) {
-				return false;
-			}
-
-			delay(100);
-		}
-
-		if (!me.mercrevivecost) { // In case we never had a merc and Config.UseMerc is still set to true for some odd reason
-			return false;
-		}
-
-		return true;
 	},
 
 	canStash: function (item) {

--- a/d2bs/kolbot/tools/ToolsThread.js
+++ b/d2bs/kolbot/tools/ToolsThread.js
@@ -26,6 +26,7 @@ include("common/Precast.js");
 include("common/Prototypes.js");
 include("common/Runewords.js");
 include("common/Storage.js");
+include("common/Mercenary.js");
 include("common/Town.js");
 
 function main() {
@@ -600,7 +601,7 @@ function main() {
 
 				if (Config.UseMerc) {
 					mercHP = getMercHP();
-					merc = me.getMerc();
+					merc = Mercenary.getMerc();
 
 					if (mercHP > 0 && merc && merc.mode !== 12) {
 						if (mercHP < Config.MercChicken) {

--- a/d2bs/kolbot/tools/TownChicken.js
+++ b/d2bs/kolbot/tools/TownChicken.js
@@ -23,6 +23,7 @@ include("common/Precast.js");
 include("common/Prototypes.js");
 include("common/Runewords.js");
 include("common/Storage.js");
+include("common/Mercenary.js");
 include("common/Town.js");
 
 function main() {


### PR DESCRIPTION
Highlights:
* Ability to hire a specific merc type of specific variant (i.e. Act2, Holy Freeze, Act3, Fire)
* Improved ability to detect merc, determine if it is dead, etc
* Checks quests to ensure that Mercs can be hired at the appropriate time (useful when smurfing)
* Safely and reliably get your bot's mercenary via Mercenary.getMerc();

To specify which merc to use, modify config as follows:
Config.UseMerc={mercType: 1, variant: 11};

mercType is set to the act# - for example, 1 for act 1 rogue merc, 5 for act 5 barb
variant is set to the skill (see sdk/skills.txt) that you want your merc to have - in this case 11 for cold arrow.
Variant can be omitted if you don't care which skill the merc has.

Notes:
* When attempting to hire a merc of a specific variant, the bot will keep hiring until the desired variant is obtained.  Be sure that your merc has enough funds when attempting to hire a merc, especially in higher difficulties or at higher levels