### PR TITLE
Added minimum game time delay to the end of muling

### DIFF
--- a/d2bs/kolbot/D2BotMule.dbj
+++ b/d2bs/kolbot/D2BotMule.dbj
@@ -521,6 +521,9 @@ function main() {
 
 					MuleData.write(obj);
 					D2Bot.printToConsole("Done muling.", 7);
+
+                    waitMinGameTime(tick);
+
 					sendCopyData(null, master, 10, JSON.stringify({status: "quit"}));
 					//delay(500);
 					D2Bot.stop(me.profile, true);
@@ -543,12 +546,7 @@ function main() {
 					nextChar();
 					D2Bot.printToConsole("Mule full, getting next character.", 7);
 
-					if (StarterConfig.MinGameTime && getTickCount() - tick < StarterConfig.MinGameTime * 1000) {
-						while (getTickCount() - tick < StarterConfig.MinGameTime * 1000) {
-							me.overhead("Stalling for " + Math.round(((tick + (StarterConfig.MinGameTime * 1000)) - getTickCount()) / 1000) + " Seconds");
-							delay(1000);
-						}
-					}
+                    waitMinGameTime(tick);
 
 					quit();
 
@@ -576,6 +574,15 @@ function main() {
 
 		delay(100);
 	}
+}
+
+function waitMinGameTime(tick) {
+    if (StarterConfig.MinGameTime && getTickCount() - tick < StarterConfig.MinGameTime * 1000) {
+    	while (getTickCount() - tick < StarterConfig.MinGameTime * 1000) {
+    		me.overhead("Stalling for " + Math.round(((tick + (StarterConfig.MinGameTime * 1000)) - getTickCount()) / 1000) + " Seconds");
+    		delay(1000);
+    	}
+    }
 }
 
 function locationAction(location) {


### PR DESCRIPTION
Before minimum game time was only considered when switching between mules. 

If you have several profiles running automule it's likely they will cause realm down since mule games can be very short and sometimes in quick succession.