### PR TITLE
Add the ability to use charged skills easily

### DIFF
--- a/d2bs/kolbot/libs/common/Misc.js
+++ b/d2bs/kolbot/libs/common/Misc.js
@@ -249,7 +249,6 @@ var Skill = {
 			return false;
 		}
 
-		// If item is given, getSkill(skillId, 1), as we dont have the skill
 		if (!item && !me.getSkill(skillId, 1)) {
 			return false;
 		}
@@ -258,7 +257,7 @@ var Skill = {
 			return false;
 		}
 
-		// No mana to cast. Charged skill dont cost mana
+		// Check mana cost, charged skills don't use mana
 		if (!item && this.getManaCost(skillId) > me.mp) {
 			// Maybe delay on ALL skills that we don't have enough mana for?
 			if (Config.AttackSkill.concat([42, 54]).concat(Config.LowManaSkill).indexOf(skillId) > -1) {
@@ -381,16 +380,16 @@ MainLoop:
 			return true;
 		}
 
-		if (!me.getSkill(skillId, 1) && !item) {
+		if (!item && !me.getSkill(skillId, 1)) {
 			return false;
 		}
 
-		// Charged skills are always right
+		// Charged skills must be cast from right hand
 		if (hand === undefined || hand === 3 || item) {
 			hand = 0;
 		}
 
-		if (me.setSkill(skillId, hand,item)) {
+		if (me.setSkill(skillId, hand, item)) {
 			return true;
 		}
 

--- a/d2bs/kolbot/libs/common/Misc.js
+++ b/d2bs/kolbot/libs/common/Misc.js
@@ -244,12 +244,13 @@ var Skill = {
 	charges: [],
 
 	// Cast a skill on self, Unit or coords
-	cast: function (skillId, hand, x, y) {
+	cast: function (skillId, hand, x, y, item) {
 		if (me.inTown && !this.townSkill(skillId)) {
 			return false;
 		}
 
-		if (!me.getSkill(skillId, 1)) {
+		// If item is given, getSkill(skillId, 1), as we dont have the skill
+		if (!item && !me.getSkill(skillId, 1)) {
 			return false;
 		}
 
@@ -257,8 +258,8 @@ var Skill = {
 			return false;
 		}
 
-		// No mana to cast
-		if (this.getManaCost(skillId) > me.mp) {
+		// No mana to cast. Charged skill dont cost mana
+		if (!item && this.getManaCost(skillId) > me.mp) {
 			// Maybe delay on ALL skills that we don't have enough mana for?
 			if (Config.AttackSkill.concat([42, 54]).concat(Config.LowManaSkill).indexOf(skillId) > -1) {
 				delay(300);
@@ -285,7 +286,7 @@ var Skill = {
 			y = me.y;
 		}
 
-		if (!this.setSkill(skillId, hand)) {
+		if (!this.setSkill(skillId, hand, item)) {
 			return false;
 		}
 
@@ -374,46 +375,23 @@ MainLoop:
 	},
 
 	// Put a skill on desired slot
-	setSkill: function (skillId, hand) {
+	setSkill: function (skillId, hand, item) {
 		// Check if the skill is already set
 		if (me.getSkill(hand === 0 ? 2 : 3) === skillId) {
 			return true;
 		}
 
-		if (!me.getSkill(skillId, 1)) {
+		if (!me.getSkill(skillId, 1) && !item) {
 			return false;
 		}
 
-		if (hand === undefined || hand === 3) {
+		// Charged skills are always right
+		if (hand === undefined || hand === 3 || item) {
 			hand = 0;
 		}
 
-		var charge = this.getCharge(skillId);
-
-		if (!!charge) {
-			// charge.charges is a cached value from Attack.getCharges
-			/*if (charge.charges > 0 && me.setSkill(skillId, hand, charge.unit)) {
-				return true;
-			}*/
-
-			return false;
-		}
-
-		if (me.setSkill(skillId, hand)) {
+		if (me.setSkill(skillId, hand,item)) {
 			return true;
-		}
-
-		return false;
-	},
-
-	// Charged skill
-	getCharge: function (skillId) {
-		var i;
-
-		for (i = 0; i < this.charges.length; i += 1) {
-			if (this.charges[i].skill === skillId && me.getSkill(skillId, 0) === this.charges[i].level && me.getSkill(skillId, 0) === me.getSkill(skillId, 1)) {
-				return this.charges[i];
-			}
 		}
 
 		return false;

--- a/d2bs/kolbot/libs/common/Misc.js
+++ b/d2bs/kolbot/libs/common/Misc.js
@@ -386,6 +386,7 @@ MainLoop:
 
 		// Charged skills must be cast from right hand
 		if (hand === undefined || hand === 3 || item) {
+			item && hand !== 0 && print('[ÿc9Warningÿc0] charged skills must be cast from right hand');
 			hand = 0;
 		}
 

--- a/d2bs/kolbot/libs/common/Prototypes.js
+++ b/d2bs/kolbot/libs/common/Prototypes.js
@@ -1147,7 +1147,6 @@ Unit.prototype.castChargedSkill = function (...args) {
 			return itemCharge.skill === skillId && itemCharge.charges;
 		};
 
-
 	switch (args.length) {
 	case 0: // item.castChargedSkill()
 		break;
@@ -1184,6 +1183,10 @@ Unit.prototype.castChargedSkill = function (...args) {
 
 	// Charged skills can only be casted on x, y coordinates
 	unit && ([x, y] = [unit.x, unit.y]);
+
+	if (this !== me && this.type === 4) {
+		throw Error("invalid arguments, expected 'me' object or 'item' unit");
+	}
 
 	if (this === me) { // Called the function the unit, me.
 		if (!skillId) {
@@ -1243,8 +1246,6 @@ Unit.prototype.castChargedSkill = function (...args) {
 
 			return true;
 		}
-	} else {
-		throw Error("invalid arguments, expected 'me' object or 'item' unit");
 	}
 
 	return false;

--- a/d2bs/kolbot/libs/common/Prototypes.js
+++ b/d2bs/kolbot/libs/common/Prototypes.js
@@ -1164,7 +1164,7 @@ Unit.prototype.useChargedSkill = function (...args) {
 				[x, y] = [...args];
 			}
 		} else {
-			throw new Error('If me.useChargedSkill with 2 arguments, it should (skillid,unit) or (x,y)');
+			throw new Error(' invalid arguments, expected (skillId, unit) or (x, y)');
 		}
 
 		break;
@@ -1241,7 +1241,7 @@ Unit.prototype.useChargedSkill = function (...args) {
 			return true;
 		}
 	} else {
-		throw Error('Needs to be called on either the me object, or a item unit');
+		throw Error("invalid arguments, expected 'me' object or 'item' unit");
 	}
 
 	return false;

--- a/d2bs/kolbot/libs/common/Prototypes.js
+++ b/d2bs/kolbot/libs/common/Prototypes.js
@@ -1104,3 +1104,115 @@ if (!Array.prototype.find) {
 		writable: true
 	});
 }
+
+/**
+ * @description very simple but handy function, that either returns the first element, or undefined
+ */
+if (!Array.prototype.first) {
+	Array.prototype.first = function () {
+		return this.length > 0 ? this[0] : undefined;
+	};
+}
+
+/**
+ * Just a simple wrapper around unit.getItem(), to avoid the use of .getNext() but just get an array,
+ * and the guaranty of getting an array ack if the unit doesnt have items
+ * @param args
+ * @returns Unit[]
+ */
+Unit.prototype.getItems = function (...args) {
+	let item = this.getItem.apply(this, args), items = [];
+	if (!item) {return [];}
+	do {items.push(copyUnit(item));} while (item.getNext());
+	return items;
+};
+
+/**
+ * @description ArachnidMesh.useChargedSkill() casts a venom or me.useChargedSkill(278);
+ * @param {int} skillId = undefined
+ * @param {int} x = undefined
+ * @param {int} y = undefined
+ */
+Unit.prototype.useChargedSkill = function (...args) {
+	let skillId, x, y, unit;
+	switch (args.length) {
+		case 0: // item.useChargedSkill()
+			break;
+		case 1:
+			if (args[0] instanceof Unit) { // hellfire.useChargedSkill(monster);
+				unit = args[0];
+			} else {
+				skillId = args[0];
+			}
+			break;
+		case 2:
+			if (typeof args[0] === 'number' && args[1] instanceof Unit) { // me.useChargedSkill(skillId,unit)
+				[skillId, unit] = [...args];
+			} else if (typeof args[0] === 'number' && typeof args[0] === 'number') { // item.useChargedSkill(x,y)
+				[x, y] = [...args];
+			} else {
+				throw new Error('If me.useChargedSkill with 2 arguments, it should (skillid,unit) or (x,y)')
+			}
+			break;
+		case 3:
+			// If all arguments are numbers
+			if (args.map(Number.isInteger).reduce((a, b) => a && b, true)) {
+				[skillId, x, y] = [...args];
+			}
+			break;
+		default:
+			throw new Error('unit.useChargedSkill() called with wrong arguments. Its either me.useChargedSkill(skillid), or item.useChargedSkill(), or me.useChargedSkill(skillid,x,y) or ')
+	}
+	// You cant cast a charged skill ON a unit, but we know where the x and y of the unit is
+	unit && ([x,y] = [unit.x,unit.y]);
+	switch (true) {
+		case this===me: // Called the function the unit, me.
+			if (!skillId) {
+				throw Error('Must supply skillId on me.useChargedSkill');
+			}
+			let sortBylvl = (a, b) => a.level - b.level,
+				filterCorrect = charge => charge.skill === skillId && charge.charges;
+			// Get all items with charges on it
+			let chargedItems = this.getItems().filter(item => item.location === 1 /*equipment*/ && item.getStat(-2)[204]);
+
+			// Filter those with the given skill, and enough charges
+			chargedItems = chargedItems.filter(item => !!item.getStat(-2)[204].filter(filterCorrect).length);
+
+			if (chargedItems.length === 0) {
+				throw Error("Don't have the charged skill (" + skillId + "), or not enough charges");
+			}
+
+			let item = chargedItems.map(item => {
+				return {item: item, charge: item.getStat(-2)[204].filter(filterCorrect).sort(sortBylvl).first()}
+			}).sort((a, b) => a.charge.level - b.charge.level)
+				.first()
+				.item;
+
+			item.useChargedSkill.apply(item, args);
+			break;
+		case this.type === 4: // called on an item
+			let charge = this.getStat(-2)[204]; // WARNING. Somehow this gives duplicates
+
+			if (!charge) {
+				throw Error('No charged skill on this item');
+			}
+
+			if (skillId) {
+				charge = charge.filter(charge => (skillId && charge.skill === skillId) && !!charge.charges); // Filter out all other charged skills
+			}
+
+			charge = charge.first();
+			if (charge) {
+				// Setting skill on hand
+				sendPacket(1, 0x3c, 2, charge.skill, 1, 0x0, 1, 0x00, 4, this.gid);
+
+				// No need for a delay, since its TCP, the server recv's the next statement always after the send cast skill packet
+
+				// The result of "successfully" casted is different, so we cant wait for it here. We have to assume it worked
+				sendPacket(1, 0x0C, 2, x || me.x, 2, y || me.y) // Cast the skill
+			}
+			break;
+		default:
+			throw Error('Needs to be called on either the me object, or a item unit')
+	}
+};

--- a/d2bs/kolbot/libs/common/Prototypes.js
+++ b/d2bs/kolbot/libs/common/Prototypes.js
@@ -1107,6 +1107,7 @@ if (!Array.prototype.find) {
 
 /**
  * @description Return the first element or undefined
+ * @return undefined|*
  */
 if (!Array.prototype.first) {
 	Array.prototype.first = function () {
@@ -1132,12 +1133,14 @@ Unit.prototype.getItems = function (...args) {
 };
 
 /**
- * @description Used upon item units like ArachnidMesh.useChargedSkill([skillId]) or directly on the "me" unit me.useChargedSkill(278);
+ * @description Used upon item units like ArachnidMesh.castChargedSkill([skillId]) or directly on the "me" unit me.castChargedSkill(278);
  * @param {int} skillId = undefined
  * @param {int} x = undefined
  * @param {int} y = undefined
+ * @return boolean
+ * @throws Error
  */
-Unit.prototype.useChargedSkill = function (...args) {
+Unit.prototype.castChargedSkill = function (...args) {
 	let skillId, x, y, unit, chargedItem, charge,
 		chargedItems = [],
 		validCharge = function (itemCharge) {
@@ -1146,10 +1149,10 @@ Unit.prototype.useChargedSkill = function (...args) {
 
 
 	switch (args.length) {
-	case 0: // item.useChargedSkill()
+	case 0: // item.castChargedSkill()
 		break;
 	case 1:
-		if (args[0] instanceof Unit) { // hellfire.useChargedSkill(monster);
+		if (args[0] instanceof Unit) { // hellfire.castChargedSkill(monster);
 			unit = args[0];
 		} else {
 			skillId = args[0];
@@ -1158,9 +1161,9 @@ Unit.prototype.useChargedSkill = function (...args) {
 		break;
 	case 2:
 		if (typeof args[0] === 'number') {
-			if (args[1] instanceof Unit) { // me.useChargedSkill(skillId,unit)
+			if (args[1] instanceof Unit) { // me.castChargedSkill(skillId,unit)
 				[skillId, unit] = [...args];
-			} else if (typeof args[1] === 'number') { // item.useChargedSkill(x,y)
+			} else if (typeof args[1] === 'number') { // item.castChargedSkill(x,y)
 				[x, y] = [...args];
 			}
 		} else {
@@ -1184,7 +1187,7 @@ Unit.prototype.useChargedSkill = function (...args) {
 
 	if (this === me) { // Called the function the unit, me.
 		if (!skillId) {
-			throw Error('Must supply skillId on me.useChargedSkill');
+			throw Error('Must supply skillId on me.castChargedSkill');
 		}
 
 		chargedItems = [];
@@ -1209,7 +1212,7 @@ Unit.prototype.useChargedSkill = function (...args) {
 
 		chargedItem = chargedItems.sort((a, b) => a.charge.level - b.charge.level).first().item;
 
-		return chargedItem.useChargedSkill.apply(chargedItem, args);
+		return chargedItem.castChargedSkill.apply(chargedItem, args);
 	} else if (this.type === 4) {
 		charge = this.getStat(-2)[204]; // WARNING. Somehow this gives duplicates
 


### PR DESCRIPTION
```javascript
    // Basic uses
    item.castChargedSkill(); 

    // Example
    let torch = me.findItem(604, 0, -1, 7);
    if (torch) {
        // Cast a hydra on x,y
        torch.castChargedSkill(x,y); 
        // OR, simply cast a hydra on the monster
        torch.castChargedSkill(monster)
    }
    
    // Or, if you dont want to search for the torch first, just simply pass the monster
    me.castChargedSkill(62 /*hydra*/,monster);
    // or the x,y
    me.castChargedSkill(62 /*hydra*/,x,y);
    
    // If you want to use no x,y, or monster, just omit them:
    me.castChargedSkill(278); // Try to cast venom of an item (Arachnid)
```
Issue reference
#795 #1099  #1494 