### PR TITLE
Equip prototype

### DIFF
--- a/d2bs/kolbot/libs/common/Misc.js
+++ b/d2bs/kolbot/libs/common/Misc.js
@@ -249,7 +249,6 @@ var Skill = {
 			return false;
 		}
 
-		// If item is given, getSkill(skillId, 1), as we dont have the skill
 		if (!item && !me.getSkill(skillId, 1)) {
 			return false;
 		}
@@ -258,7 +257,7 @@ var Skill = {
 			return false;
 		}
 
-		// No mana to cast. Charged skill dont cost mana
+		// Check mana cost, charged skills don't use mana
 		if (!item && this.getManaCost(skillId) > me.mp) {
 			// Maybe delay on ALL skills that we don't have enough mana for?
 			if (Config.AttackSkill.concat([42, 54]).concat(Config.LowManaSkill).indexOf(skillId) > -1) {
@@ -381,16 +380,16 @@ MainLoop:
 			return true;
 		}
 
-		if (!me.getSkill(skillId, 1) && !item) {
+		if (!item && !me.getSkill(skillId, 1)) {
 			return false;
 		}
 
-		// Charged skills are always right
+		// Charged skills must be cast from right hand
 		if (hand === undefined || hand === 3 || item) {
 			hand = 0;
 		}
 
-		if (me.setSkill(skillId, hand,item)) {
+		if (me.setSkill(skillId, hand, item)) {
 			return true;
 		}
 

--- a/d2bs/kolbot/libs/common/Misc.js
+++ b/d2bs/kolbot/libs/common/Misc.js
@@ -244,12 +244,13 @@ var Skill = {
 	charges: [],
 
 	// Cast a skill on self, Unit or coords
-	cast: function (skillId, hand, x, y) {
+	cast: function (skillId, hand, x, y, item) {
 		if (me.inTown && !this.townSkill(skillId)) {
 			return false;
 		}
 
-		if (!me.getSkill(skillId, 1)) {
+		// If item is given, getSkill(skillId, 1), as we dont have the skill
+		if (!item && !me.getSkill(skillId, 1)) {
 			return false;
 		}
 
@@ -257,8 +258,8 @@ var Skill = {
 			return false;
 		}
 
-		// No mana to cast
-		if (this.getManaCost(skillId) > me.mp) {
+		// No mana to cast. Charged skill dont cost mana
+		if (!item && this.getManaCost(skillId) > me.mp) {
 			// Maybe delay on ALL skills that we don't have enough mana for?
 			if (Config.AttackSkill.concat([42, 54]).concat(Config.LowManaSkill).indexOf(skillId) > -1) {
 				delay(300);
@@ -285,7 +286,7 @@ var Skill = {
 			y = me.y;
 		}
 
-		if (!this.setSkill(skillId, hand)) {
+		if (!this.setSkill(skillId, hand, item)) {
 			return false;
 		}
 
@@ -374,46 +375,23 @@ MainLoop:
 	},
 
 	// Put a skill on desired slot
-	setSkill: function (skillId, hand) {
+	setSkill: function (skillId, hand, item) {
 		// Check if the skill is already set
 		if (me.getSkill(hand === 0 ? 2 : 3) === skillId) {
 			return true;
 		}
 
-		if (!me.getSkill(skillId, 1)) {
+		if (!me.getSkill(skillId, 1) && !item) {
 			return false;
 		}
 
-		if (hand === undefined || hand === 3) {
+		// Charged skills are always right
+		if (hand === undefined || hand === 3 || item) {
 			hand = 0;
 		}
 
-		var charge = this.getCharge(skillId);
-
-		if (!!charge) {
-			// charge.charges is a cached value from Attack.getCharges
-			/*if (charge.charges > 0 && me.setSkill(skillId, hand, charge.unit)) {
-				return true;
-			}*/
-
-			return false;
-		}
-
-		if (me.setSkill(skillId, hand)) {
+		if (me.setSkill(skillId, hand,item)) {
 			return true;
-		}
-
-		return false;
-	},
-
-	// Charged skill
-	getCharge: function (skillId) {
-		var i;
-
-		for (i = 0; i < this.charges.length; i += 1) {
-			if (this.charges[i].skill === skillId && me.getSkill(skillId, 0) === this.charges[i].level && me.getSkill(skillId, 0) === me.getSkill(skillId, 1)) {
-				return this.charges[i];
-			}
 		}
 
 		return false;

--- a/d2bs/kolbot/libs/common/Prototypes.js
+++ b/d2bs/kolbot/libs/common/Prototypes.js
@@ -1,8 +1,8 @@
 /**
-*	@filename	Prototypes.js
-*	@author		kolton
-*	@desc		various 'Unit' and 'me' prototypes
-*/
+ *    @filename    Prototypes.js
+ *    @author        kolton
+ *    @desc        various 'Unit' and 'me' prototypes
+ */
 
 // Shuffle Array
 // http://stackoverflow.com/questions/6274339/how-can-i-shuffle-an-array-in-javascript
@@ -1245,4 +1245,143 @@ Unit.prototype.useChargedSkill = function (...args) {
 	}
 
 	return false;
+};
+
+/**
+ * @description equip an item.
+ */
+Unit.prototype.equip = function (destLocation = undefined) {
+	let doubleHanded = [26, 27, 34, 35, 67, 85, 86], spot,
+		clickItemAndWait = (...args) => {
+			let before = me.itemoncursor,
+				itemEvent = false,
+				timeout = getTickCount(),
+				gamePacket = bytes => bytes && bytes.length > 0 && bytes[0] === 0x9D /* item event*/ && (itemEvent = true) && false; // false to not block
+
+			addEventListener('gamepacket', gamePacket);
+
+			clickItem.apply(undefined, args);
+			delay(Math.max(me.ping, 50));
+
+			while (!itemEvent) { // Wait until item is picked up.
+				delay(3);
+
+				if (/*before !== me.itemoncursor || */ getTickCount() - timeout > Math.min(1000, 100 + (me.ping * 4))) {
+					break; // quit the loop of item on cursor has changed
+				}
+			}
+
+			removeEventListener('gamepacket', gamePacket);
+			delay(Math.max(me.ping, 50));
+			itemEvent = false;
+		}, findspot = function (item) {
+			let tempspot = Storage.Stash.FindSpot(item);
+
+			if (getUIFlag(0x19) && tempspot) {
+				return {location: Storage.Stash.location, coord: tempspot};
+			}
+
+			tempspot = Storage.Inventory.FindSpot(item);
+
+			if (tempspot) {
+				return {location: Storage.Inventory.location, coord: tempspot};
+			}
+
+			return false; // no spot found
+		};
+
+	// Not an item, or unidentified, or not enough stats
+	if (this.type !== 4 || !this.getFlag(0x10) || this.getStat(92) > me.getStat(12) || this.dexreq > me.getStat(2) || this.strreq > me.getStat(0)) {
+		return false;
+	}
+
+	// If not a specific location is given, figure it out (can be useful to equip a double weapon)
+	(destLocation || (destLocation = this.getBodyLoc())) && !Array.isArray(destLocation) && (destLocation = [destLocation]);
+
+	print('equiping ' + this.name);
+
+	if (this.location === 1) {
+		return true; // Item is equiped
+	}
+
+
+	let currentEquiped = me.getItems(-1).filter(item =>
+		destLocation.indexOf(item.bodylocation) !== -1
+		|| ( // Deal with double handed weapons
+
+			(item.bodylocation === 4 || item.bodylocation === 5)
+			&& [4, 5].indexOf(destLocation) // in case destination is on the weapon/shield slot
+			&& (
+				doubleHanded.indexOf(this.itemType) !== -1 // this item is a double handed item
+				|| doubleHanded.indexOf(item.itemType) !== -1 // current item is a double handed item
+			)
+		)
+	).sort((a, b) => b - a); // shields first
+
+	// if nothing is equipped at the moment, just equip it
+	if (!currentEquiped.length) {
+		clickItemAndWait(0, this);
+		clickItemAndWait(0, destLocation.first());
+	} else { // unequip / swap items
+		currentEquiped.forEach((item, index) => {
+
+			// Last item, so swap instead of putting off first
+			if (index === (currentEquiped.length - 1)) {
+				print('swap ' + this.name + ' for ' + item.name);
+				let oldLoc = {x: this.x, y: this.y, location: this.location};
+				clickItemAndWait(0, this); // Pick up current item
+				clickItemAndWait(0, destLocation.first()); // the swap of items
+				// Find a spot for the current item
+				spot = findspot(item);
+
+				if (!spot) { // If no spot is found for the item, rollback
+					clickItemAndWait(0, destLocation.first()); // swap again
+					clickItemAndWait(0, oldLoc.x, oldLoc.y, oldLoc.location); // put item back on old spot
+					throw Error('cant find spot for unequipped item');
+				}
+
+				clickItemAndWait(0, spot.coord.y, spot.coord.x, spot.location); // put item on the found spot
+
+				return;
+			}
+
+			print('Unequip item first ' + item.name);
+			// Incase multiple items are equipped
+			spot = findspot(item); // Find a spot for the current item
+
+			if (!spot) {
+				throw Error('cant find spot for unequipped item');
+			}
+
+			clickItemAndWait(0, item.bodylocation);
+			clickItemAndWait(0, spot.coord.x, spot.coord.y, spot.location);
+		});
+	}
+
+	return {
+		success: this.bodylocation === destLocation.first(),
+		unequiped: currentEquiped,
+		rollback: () => currentEquiped.forEach(item => item.equip()) // Note; rollback only works if you had other items equipped before.
+	};
+};
+
+Unit.prototype.getBodyLoc = function () {
+	let types = {
+			1: [37, 71, 75], // helm
+			2: [12], // amulet
+			3: [3], // armor
+			4: [24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 42, 43, 44, 67, 68, 69, 72, 85, 86, 87, 88], // weapons
+			5: [2, 5, 6, 70], // shields / Arrows / bolts
+			6: [10], // ring slot 1
+			7: [10], // ring slot 2
+			8: [19], // belt
+			9: [15], // boots
+			10: [16], // gloves
+		}, bodyLoc = [];
+
+	for (let i in types) {
+		this.itemType && types[i].indexOf(this.itemType) !== -1 && bodyLoc.push(i);
+	}
+
+	return bodyLoc.map(loc => parseInt(loc));
 };

--- a/d2bs/kolbot/libs/common/Prototypes.js
+++ b/d2bs/kolbot/libs/common/Prototypes.js
@@ -1164,7 +1164,7 @@ Unit.prototype.useChargedSkill = function (...args) {
 				[x, y] = [...args];
 			}
 		} else {
-			throw new Error('If me.useChargedSkill with 2 arguments, it should (skillid,unit) or (x,y)');
+			throw new Error(' invalid arguments, expected (skillId, unit) or (x, y)');
 		}
 
 		break;
@@ -1241,7 +1241,7 @@ Unit.prototype.useChargedSkill = function (...args) {
 			return true;
 		}
 	} else {
-		throw Error('Needs to be called on either the me object, or a item unit');
+		throw Error("invalid arguments, expected 'me' object or 'item' unit");
 	}
 
 	return false;

--- a/d2bs/kolbot/libs/common/Prototypes.js
+++ b/d2bs/kolbot/libs/common/Prototypes.js
@@ -1104,3 +1104,115 @@ if (!Array.prototype.find) {
 		writable: true
 	});
 }
+
+/**
+ * @description very simple but handy function, that either returns the first element, or undefined
+ */
+if (!Array.prototype.first) {
+	Array.prototype.first = function () {
+		return this.length > 0 ? this[0] : undefined;
+	};
+}
+
+/**
+ * Just a simple wrapper around unit.getItem(), to avoid the use of .getNext() but just get an array,
+ * and the guaranty of getting an array ack if the unit doesnt have items
+ * @param args
+ * @returns Unit[]
+ */
+Unit.prototype.getItems = function (...args) {
+	let item = this.getItem.apply(this, args), items = [];
+	if (!item) {return [];}
+	do {items.push(copyUnit(item));} while (item.getNext());
+	return items;
+};
+
+/**
+ * @description ArachnidMesh.useChargedSkill() casts a venom or me.useChargedSkill(278);
+ * @param {int} skillId = undefined
+ * @param {int} x = undefined
+ * @param {int} y = undefined
+ */
+Unit.prototype.useChargedSkill = function (...args) {
+	let skillId, x, y, unit;
+	switch (args.length) {
+		case 0: // item.useChargedSkill()
+			break;
+		case 1:
+			if (args[0] instanceof Unit) { // hellfire.useChargedSkill(monster);
+				unit = args[0];
+			} else {
+				skillId = args[0];
+			}
+			break;
+		case 2:
+			if (typeof args[0] === 'number' && args[1] instanceof Unit) { // me.useChargedSkill(skillId,unit)
+				[skillId, unit] = [...args];
+			} else if (typeof args[0] === 'number' && typeof args[0] === 'number') { // item.useChargedSkill(x,y)
+				[x, y] = [...args];
+			} else {
+				throw new Error('If me.useChargedSkill with 2 arguments, it should (skillid,unit) or (x,y)')
+			}
+			break;
+		case 3:
+			// If all arguments are numbers
+			if (args.map(Number.isInteger).reduce((a, b) => a && b, true)) {
+				[skillId, x, y] = [...args];
+			}
+			break;
+		default:
+			throw new Error('unit.useChargedSkill() called with wrong arguments. Its either me.useChargedSkill(skillid), or item.useChargedSkill(), or me.useChargedSkill(skillid,x,y) or ')
+	}
+	// You cant cast a charged skill ON a unit, but we know where the x and y of the unit is
+	unit && ([x,y] = [unit.x,unit.y]);
+	switch (true) {
+		case this===me: // Called the function the unit, me.
+			if (!skillId) {
+				throw Error('Must supply skillId on me.useChargedSkill');
+			}
+			let sortBylvl = (a, b) => a.level - b.level,
+				filterCorrect = charge => charge.skill === skillId && charge.charges;
+			// Get all items with charges on it
+			let chargedItems = this.getItems().filter(item => item.location === 1 /*equipment*/ && item.getStat(-2)[204]);
+
+			// Filter those with the given skill, and enough charges
+			chargedItems = chargedItems.filter(item => !!item.getStat(-2)[204].filter(filterCorrect).length);
+
+			if (chargedItems.length === 0) {
+				throw Error("Don't have the charged skill (" + skillId + "), or not enough charges");
+			}
+
+			let item = chargedItems.map(item => {
+				return {item: item, charge: item.getStat(-2)[204].filter(filterCorrect).sort(sortBylvl).first()}
+			}).sort((a, b) => a.charge.level - b.charge.level)
+				.first()
+				.item;
+
+			item.useChargedSkill.apply(item, args);
+			break;
+		case this.type === 4: // called on an item
+			let charge = this.getStat(-2)[204]; // WARNING. Somehow this gives duplicates
+
+			if (!charge) {
+				throw Error('No charged skill on this item');
+			}
+
+			if (skillId) {
+				charge = charge.filter(charge => (skillId && charge.skill === skillId) && !!charge.charges); // Filter out all other charged skills
+			}
+
+			charge = charge.first();
+			if (charge) {
+				// Setting skill on hand
+				sendPacket(1, 0x3c, 2, charge.skill, 1, 0x0, 1, 0x00, 4, this.gid);
+
+				// No need for a delay, since its TCP, the server recv's the next statement always after the send cast skill packet
+
+				// The result of "successfully" casted is different, so we cant wait for it here. We have to assume it worked
+				sendPacket(1, 0x0C, 2, x || me.x, 2, y || me.y) // Cast the skill
+			}
+			break;
+		default:
+			throw Error('Needs to be called on either the me object, or a item unit')
+	}
+};


### PR DESCRIPTION
Added the prototype equip for units (items).

The goal is to make it more easy to equip an item, without knowledge of the currently equiped items.

For example, this code goes to stash, equips memory, cast energy shield and put the previous items back on. It figures out if you go from a double handed to a single handed item, or vice versa.

Please note i use the same prototypes of charged skills in here, so this needs to be merged first.

`Town.move('stash') && Town.openStash();

		let oldItems = me.getItems(-1).filter(item => item.getPrefix(20588 /*memory*/)).first().equip();

		Skill.cast(58);
		Town.openStash();

		oldItems.rollback(); // put old items back
`
edit; typo