### PR TITLE
Don't over bo a better bo.

### DIFF
--- a/d2bs/kolbot/libs/common/Precast.js
+++ b/d2bs/kolbot/libs/common/Precast.js
@@ -570,8 +570,6 @@ var Precast = new function () {
 
 				// Bit 135 rules the type of packet it is. 0 = high bo (>=128), 1= low bo (=<127)
 				position = position[bits[135]];
-				print(packetbytes.map(x=>format(x.toString(16),2)).join(' '));
-				print(bits.join(''));
 				Precast.BOEffect = parseInt(bits.splice(position.p, position.l).join(''), 2);
 				Precast.BOTick = getTickCount();
 				boLvl = ((Precast.BOEffect - 32) / 3);


### PR DESCRIPTION
## Goal
Do not cast battle orders, if you received a bo of a higher lvl.

## Why?
What is worse as seeing your team receiving a high bo, only to get ruined by one of your chars that over bo's it with a crappy bo. This is my attempt make this happen less often (it will not be perfect)


## How?
I written a gamepacket event, that handles, parses and deal with the state packet of battle orders. It calculates your own bo lvl and combined with the info of a gotten state, it prevents a over-bo with a lower lvl.


## Does it work?
Yes and no. The parsing of the packet isnt perfect or well tested yet. So far it is going good, but i feel like im missing something. So i would like it if some people could test it.


## Configuration
Nothing. This, when it works and is merged, is just a part of the Precasting part of kolton. It doesnt need to communicate with other clients, or something like that. It runs standalone, and when finished and merged, just included in kolton and works for every precasting bot. As this is an addition to precast, and not a change, it doesnt change the way it precasts now. It just doesnt use bo when it got a better bo.
 