### PR TITLE
Add BattleOrders tardy check and quit/continue vars

### DIFF
--- a/d2bs/kolbot/libs/common/Config.js
+++ b/d2bs/kolbot/libs/common/Config.js
@@ -415,7 +415,10 @@ var Config = {
 	BattleOrders: {
 		Mode: 0,
 		Getters: [],
-		Wait: false
+		Wait: false,
+		QuitOnFailedGive: false,
+		QuitOnFailedGet: false,
+		SkipIfTardy: true
 	},
 	Enchant: {
 		Triggers: ["chant", "cows", "wps"],


### PR DESCRIPTION
This removes the unnecessary delay when someone rejoins a game or joins
late and the time for battle orders has passed. The bot will now check
for other player locations and just continue on instead of waiting the
BattleOrder timeout. Instead of quitting if the timeout is reached,
now the character can optionally just continue on with the run. These
two changes combined make for smoother battle order control.