### PR TITLE
Add implementation of Config.ClearPath to bot scripts

### DIFF
--- a/d2bs/kolbot/libs/bots/Abaddon.js
+++ b/d2bs/kolbot/libs/bots/Abaddon.js
@@ -9,7 +9,7 @@ function Abaddon() {
 	Pather.useWaypoint(111);
 	Precast.doPrecast(true);
 
-	if (!Pather.moveToPreset(111, 2, 60) || !Pather.usePortal(125)) {
+	if (!Pather.moveToPreset(111, 2, 60, 0, 0, Config.ClearPath) || !Pather.usePortal(125)) {
 		throw new Error("Failed to move to Abaddon");
 	}
 

--- a/d2bs/kolbot/libs/bots/AncientTunnels.js
+++ b/d2bs/kolbot/libs/bots/AncientTunnels.js
@@ -9,15 +9,15 @@ function AncientTunnels() {
 	Pather.useWaypoint(44);
 	Precast.doPrecast(true);
 
-	if (Config.AncientTunnels.OpenChest && Pather.moveToPreset(me.area, 2, 580) && Misc.openChests(5)) {
+	if (Config.AncientTunnels.OpenChest && Pather.moveToPreset(me.area, 2, 580, 0, 0, Config.ClearPath) && Misc.openChests(5)) {
 		Pickit.pickItems();
 	}
 
-	if (Config.AncientTunnels.KillDarkElder && getPresetUnit(me.area, 1, 751) && Pather.moveToPreset(me.area, 1, 751)) {
+	if (Config.AncientTunnels.KillDarkElder && getPresetUnit(me.area, 1, 751) && Pather.moveToPreset(me.area, 1, 751, 0, 0, Config.ClearPath)) {
 		Attack.clear(15, 0, getLocaleString(2886));
 	}
 
-	if (!Pather.moveToExit(65, true)) {
+	if (!Pather.moveToExit(65, true, Config.ClearPath)) {
 		throw new Error("Failed to move to Ancient Tunnels");
 	}
 

--- a/d2bs/kolbot/libs/bots/Andariel.js
+++ b/d2bs/kolbot/libs/bots/Andariel.js
@@ -37,7 +37,7 @@ function Andariel () {
 	Pather.useWaypoint(35);
 	Precast.doPrecast(true);
 
-	if (!Pather.moveToExit([36, 37], true)) {
+	if (!Pather.moveToExit([36, 37], true, Config.ClearPath)) {
 		throw new Error("Failed to move to Catacombs Level 4");
 	}
 

--- a/d2bs/kolbot/libs/bots/Baal.js
+++ b/d2bs/kolbot/libs/bots/Baal.js
@@ -204,7 +204,7 @@ function Baal() {
 		Pather.useWaypoint(129);
 	}
 
-	if (!Pather.moveToExit([130, 131], true)) {
+	if (!Pather.moveToExit([130, 131], true, Config.ClearPath)) {
 		throw new Error("Failed to move to Throne of Destruction.");
 	}
 

--- a/d2bs/kolbot/libs/bots/BoneAsh.js
+++ b/d2bs/kolbot/libs/bots/BoneAsh.js
@@ -9,7 +9,7 @@ function BoneAsh() {
 	Pather.useWaypoint(32);
 	Precast.doPrecast(true);
 
-	if (!Pather.moveTo(20047, 4898)) {
+	if (!Pather.moveTo(20047, 4898, 3, Config.ClearPath)) {
 		throw new Error("Failed to move to Bone Ash");
 	}
 

--- a/d2bs/kolbot/libs/bots/Bonesaw.js
+++ b/d2bs/kolbot/libs/bots/Bonesaw.js
@@ -9,13 +9,13 @@ function Bonesaw() {
 	Pather.useWaypoint(115);
 	Precast.doPrecast(true);
 
-	if (!Pather.moveToPreset(115, 2, 455, 15, 15)) {
+	if (!Pather.moveToPreset(115, 2, 455, 15, 15, Config.ClearPath)) {
 		throw new Error("Failed to move to Bonesaw");
 	}
 
 	Attack.clear(15, 0, getLocaleString(22502)); // Bonesaw Breaker
 
-	if (Config.Bonesaw.ClearDrifterCavern && Pather.moveToExit(116, true)) {
+	if (Config.Bonesaw.ClearDrifterCavern && Pather.moveToExit(116, true, Config.ClearPath)) {
 		Attack.clearLevel(Config.ClearType);
 	}
 

--- a/d2bs/kolbot/libs/bots/Coldcrow.js
+++ b/d2bs/kolbot/libs/bots/Coldcrow.js
@@ -9,11 +9,11 @@ function Coldcrow() {
 	Pather.useWaypoint(3);
 	Precast.doPrecast(true);
 
-	if (!Pather.moveToExit(9, true, false)) {
+	if (!Pather.moveToExit(9, true, Config.ClearPath)) {
 		throw new Error("Failed to move to Cave");
 	}
 
-	if (!Pather.moveToPreset(me.area, 1, 736, 0, 0, false)) {
+	if (!Pather.moveToPreset(me.area, 1, 736, 0, 0, Config.ClearPath)) {
 		throw new Error("Failed to move to Coldcrow");
 	}
 

--- a/d2bs/kolbot/libs/bots/Coldworm.js
+++ b/d2bs/kolbot/libs/bots/Coldworm.js
@@ -13,7 +13,7 @@ function Coldworm() {
 
 	// Beetleburst, added by 13ack.Stab
 	if (Config.Coldworm.KillBeetleburst) {
-		if (!Pather.moveToPreset(me.area, 1, 747)) {
+		if (!Pather.moveToPreset(me.area, 1, 747, 0, 0, Config.ClearPath)) {
 			throw new Error("Failed to move to Beetleburst");
 		}
 
@@ -21,7 +21,7 @@ function Coldworm() {
 	}
 
 	for (i = 62; i <= 64; i += 1) {
-		if (!Pather.moveToExit(i, true)) {
+		if (!Pather.moveToExit(i, true, Config.ClearPath)) {
 			throw new Error("Failed to move to Coldworm");
 		}
 
@@ -31,7 +31,7 @@ function Coldworm() {
 	}
 
 	if (!Config.Coldworm.ClearMaggotLair) {
-		if (!Pather.moveToPreset(me.area, 2, 356)) {
+		if (!Pather.moveToPreset(me.area, 2, 356, 0, 0, Config.ClearPath)) {
 			throw new Error("Failed to move to Coldworm");
 		}
 

--- a/d2bs/kolbot/libs/bots/Corpsefire.js
+++ b/d2bs/kolbot/libs/bots/Corpsefire.js
@@ -9,7 +9,7 @@ function Corpsefire() {
 	Pather.useWaypoint(3);
 	Precast.doPrecast(true);
 
-	if (!Pather.moveToExit([2, 8], true) || !Pather.moveToPreset(me.area, 1, 774, 0, 0, false, true)) {
+	if (!Pather.moveToExit([2, 8], true, Config.ClearPath) || !Pather.moveToPreset(me.area, 1, 774, 0, 0, Config.ClearPath, true)) {
 		throw new Error("Failed to move to Corpsefire");
 	}
 

--- a/d2bs/kolbot/libs/bots/Countess.js
+++ b/d2bs/kolbot/libs/bots/Countess.js
@@ -11,7 +11,7 @@ function Countess() {
 	Pather.useWaypoint(6);
 	Precast.doPrecast(true);
 
-	if (!Pather.moveToExit([20, 21, 22, 23, 24, 25], true)) {
+	if (!Pather.moveToExit([20, 21, 22, 23, 24, 25], true, Config.ClearPath)) {
 		throw new Error("Failed to move to Countess");
 	}
 
@@ -23,10 +23,10 @@ function Countess() {
 
 	switch (poi.roomx * 5 + poi.x) {
 	case 12565:
-		Pather.moveTo(12578, 11043);
+		Pather.moveTo(12578, 11043, 3, Config.ClearPath);
 		break;
 	case 12526:
-		Pather.moveTo(12548, 11083);
+		Pather.moveTo(12548, 11083, 3, Config.ClearPath);
 		break;
 	}
 

--- a/d2bs/kolbot/libs/bots/Diablo.js
+++ b/d2bs/kolbot/libs/bots/Diablo.js
@@ -431,7 +431,7 @@ function Diablo() {
 		Pather.useWaypoint(107);
 	}
 
-	if (!Pather.moveTo(7790, 5544)) {
+	if (!Pather.moveTo(7790, 5544, 3, Config.ClearPath)) {
 		throw new Error("Failed to move to Chaos Sanctuary");
 	}
 

--- a/d2bs/kolbot/libs/bots/Duriel.js
+++ b/d2bs/kolbot/libs/bots/Duriel.js
@@ -51,11 +51,11 @@ function Duriel () {
 
 	Precast.doPrecast(true);
 
-	if (!Pather.moveToExit(getRoom().correcttomb, true)) {
+	if (!Pather.moveToExit(getRoom().correcttomb, true, Config.ClearPath)) {
 		throw new Error("Failed to move to Tal Rasha's Tomb");
 	}
 
-	if (!Pather.moveToPreset(me.area, 2, 152, -11, 3)) {
+	if (!Pather.moveToPreset(me.area, 2, 152, -11, 3, Config.ClearPath)) {
 		throw new Error("Failed to move to Orifice");
 	}
 

--- a/d2bs/kolbot/libs/bots/Eldritch.js
+++ b/d2bs/kolbot/libs/bots/Eldritch.js
@@ -10,14 +10,14 @@ function Eldritch() {
 	Town.doChores();
 	Pather.useWaypoint(111);
 	Precast.doPrecast(true);
-	Pather.moveTo(3745, 5084);
+	Pather.moveTo(3745, 5084, 3, Config.ClearPath);
 	Attack.clear(15, 0, getLocaleString(22500)); // Eldritch the Rectifier
 
 	if (Config.Eldritch.OpenChest) {
 		chest = getPresetUnit(me.area, 2, 455);
 
 		if (chest) {
-			Pather.moveToUnit(chest);
+			Pather.moveToUnit(chest, 0, 0, Config.ClearPath);
 
 			chest = getUnit(2, 455);
 
@@ -28,12 +28,12 @@ function Eldritch() {
 	}
 
 	if (Config.Eldritch.KillShenk) {
-		Pather.moveTo(3876, 5130);
+		Pather.moveTo(3876, 5130, 3, Config.ClearPath);
 		Attack.clear(15, 0, getLocaleString(22435)); // Shenk the Overseer
 	}
 
 	if (Config.Eldritch.KillDacFarren) {
-		Pather.moveTo(4478, 5108);
+		Pather.moveTo(4478, 5108, 3, Config.ClearPath);
 		Attack.clear(15, 0, getLocaleString(22501)); // Dac Farren
 	}
 

--- a/d2bs/kolbot/libs/bots/Endugu.js
+++ b/d2bs/kolbot/libs/bots/Endugu.js
@@ -9,7 +9,7 @@ function Endugu() {
 	Pather.useWaypoint(78);
 	Precast.doPrecast(true);
 
-	if (!Pather.moveToExit([88, 89, 91], true) || !Pather.moveToPreset(me.area, 2, 406)) {
+	if (!Pather.moveToExit([88, 89, 91], true, Config.ClearPath) || !Pather.moveToPreset(me.area, 2, 406, 0, 0, Config.ClearPath)) {
 		throw new Error("Failed to move to Endugu");
 	}
 

--- a/d2bs/kolbot/libs/bots/Eyeback.js
+++ b/d2bs/kolbot/libs/bots/Eyeback.js
@@ -9,7 +9,7 @@ function Eyeback() {
 	Pather.useWaypoint(112);
 	Precast.doPrecast(true);
 
-	if (!Pather.moveToPreset(111, 1, 784)) {
+	if (!Pather.moveToPreset(111, 1, 784, 0, 0, Config.ClearPath)) {
 		throw new Error("Failed to move to Eyeback the Unleashed");
 	}
 

--- a/d2bs/kolbot/libs/bots/Frozenstein.js
+++ b/d2bs/kolbot/libs/bots/Frozenstein.js
@@ -9,7 +9,7 @@ function Frozenstein() {
 	Pather.useWaypoint(113);
 	Precast.doPrecast(true);
 
-	if (!Pather.moveToExit(114, true) || !Pather.moveToPreset(me.area, 2, 460, -5, -5)) {
+	if (!Pather.moveToExit(114, true, Config.ClearPath) || !Pather.moveToPreset(me.area, 2, 460, -5, -5, Config.ClearPath)) {
 		throw new Error("Failed to move to Frozenstein");
 	}
 

--- a/d2bs/kolbot/libs/bots/GetKeys.js
+++ b/d2bs/kolbot/libs/bots/GetKeys.js
@@ -7,7 +7,7 @@ function GetKeys() {
 			Pather.useWaypoint(6);
 			Precast.doPrecast(true);
 			Pather.journeyTo(25);
-			Pather.moveToPreset(me.area, 2, 580);
+			Pather.moveToPreset(me.area, 2, 580, 0, 0, Config.ClearPath);
 			Attack.kill(getLocaleString(2875));
 			Pickit.pickItems();
 		} catch (countessError) {
@@ -22,7 +22,7 @@ function GetKeys() {
 			Town.doChores();
 			Pather.useWaypoint(74);
 			Precast.doPrecast(true);
-			Pather.moveToPreset(me.area, 2, 357, -3, -3);
+			Pather.moveToPreset(me.area, 2, 357, -3, -3, Config.ClearPath);
 			Attack.kill(250);
 			Pickit.pickItems();
 		} catch (summonerError) {
@@ -37,8 +37,8 @@ function GetKeys() {
 			Town.doChores();
 			Pather.useWaypoint(123);
 			Precast.doPrecast(true);
-			Pather.moveToExit(124, true);
-			Pather.moveToPreset(me.area, 2, 462);
+			Pather.moveToExit(124, true, Config.ClearPath);
+			Pather.moveToPreset(me.area, 2, 462, 0, 0, Config.ClearPath);
 			Attack.kill(526);
 			Pickit.pickItems();
 		} catch (nihlathakError) {

--- a/d2bs/kolbot/libs/bots/Hephasto.js
+++ b/d2bs/kolbot/libs/bots/Hephasto.js
@@ -9,7 +9,7 @@ function Hephasto() {
 	Pather.useWaypoint(107);
 	Precast.doPrecast(true);
 
-	if (!Pather.moveToPreset(me.area, 2, 376)) {
+	if (!Pather.moveToPreset(me.area, 2, 376, 0, 0, Config.ClearPath)) {
 		throw new Error("Failed to move to Hephasto");
 	}
 

--- a/d2bs/kolbot/libs/bots/Icehawk.js
+++ b/d2bs/kolbot/libs/bots/Icehawk.js
@@ -9,7 +9,7 @@ function Icehawk() {
 	Pather.useWaypoint(80);
 	Precast.doPrecast(true);
 
-	if (!Pather.moveToExit([92, 93], false)) {
+	if (!Pather.moveToExit([92, 93], false, Config.ClearPath)) {
 		throw new Error("Failed to move to Icehawk");
 	}
 

--- a/d2bs/kolbot/libs/bots/Izual.js
+++ b/d2bs/kolbot/libs/bots/Izual.js
@@ -9,7 +9,7 @@ function Izual() {
 	Pather.useWaypoint(106);
 	Precast.doPrecast(true);
 
-	if (!Pather.moveToPreset(105, 1, 256)) {
+	if (!Pather.moveToPreset(105, 1, 256, 0, 0, Config.ClearPath)) {
 		throw new Error("Failed to move to Izual.");
 	}
 

--- a/d2bs/kolbot/libs/bots/Mephisto.js
+++ b/d2bs/kolbot/libs/bots/Mephisto.js
@@ -134,7 +134,7 @@ function Mephisto() {
 	Pather.useWaypoint(101);
 	Precast.doPrecast(true);
 
-	if (!Pather.moveToExit(102, true)) {
+	if (!Pather.moveToExit(102, true, Config.ClearPath)) {
 		throw new Error("Failed to move to Durance Level 3");
 	}
 

--- a/d2bs/kolbot/libs/bots/Nihlathak.js
+++ b/d2bs/kolbot/libs/bots/Nihlathak.js
@@ -9,11 +9,11 @@ function Nihlathak() {
 	Pather.useWaypoint(123);
 	Precast.doPrecast(false);
 
-	if (!Pather.moveToExit(124, true)) {
+	if (!Pather.moveToExit(124, true, Config.ClearPath)) {
 		throw new Error("Failed to go to Nihlathak");
 	}
 
-	Pather.moveToPreset(me.area, 2, 462, 0, 0, false, true);
+	Pather.moveToPreset(me.area, 2, 462, 0, 0, Config.ClearPath, true);
 
 	if (Config.Nihlathak.ViperQuit && getUnit(1, 597)) {
 		print("Tomb Vipers found.");

--- a/d2bs/kolbot/libs/bots/Pindleskin.js
+++ b/d2bs/kolbot/libs/bots/Pindleskin.js
@@ -14,7 +14,7 @@ function Pindleskin() {
 		Pather.useWaypoint(123);
 		Precast.doPrecast(true);
 
-		if (!Pather.moveToExit([122, 121], true)) {
+		if (!Pather.moveToExit([122, 121], true, Config.ClearPath)) {
 			throw new Error("Failed to move to Nihlahak's Temple");
 		}
 	} else {
@@ -45,11 +45,11 @@ function Pindleskin() {
 	}
 
 	if (Config.Pindleskin.KillNihlathak) {
-		if (!Pather.moveToExit([122, 123, 124], true)) {
+		if (!Pather.moveToExit([122, 123, 124], true, Config.ClearPath)) {
 			throw new Error("Failed to move to Halls of Vaught");
 		}
 
-		Pather.moveToPreset(me.area, 2, 462, 10, 10);
+		Pather.moveToPreset(me.area, 2, 462, 10, 10, Config.ClearPath);
 
 		if (Config.Pindleskin.ViperQuit && getUnit(1, 597)) {
 			print("Tomb Vipers found.");

--- a/d2bs/kolbot/libs/bots/Pit.js
+++ b/d2bs/kolbot/libs/bots/Pit.js
@@ -9,7 +9,7 @@ function Pit() {
 	Pather.useWaypoint(6);
 	Precast.doPrecast(true);
 
-	if (!Pather.moveToExit([7, 12], true)) {
+	if (!Pather.moveToExit([7, 12], true, Config.ClearPath)) {
 		throw new Error("Failed to move to Pit level 1");
 	}
 
@@ -17,7 +17,7 @@ function Pit() {
 		Attack.clearLevel(Config.ClearType);
 	}
 
-	if (!Pather.moveToExit(16, true, Config.Pit.ClearPath)) {
+	if (!Pather.moveToExit(16, true, Config.Pit.ClearPath || Config.ClearPath)) {
 		throw new Error("Failed to move to Pit level 2");
 	}
 

--- a/d2bs/kolbot/libs/bots/Questing.js
+++ b/d2bs/kolbot/libs/bots/Questing.js
@@ -59,7 +59,7 @@ function Questing() {
 
 		Precast.doPrecast(true);
 
-		if (!Pather.moveToExit(49, true) || !Pather.moveToPreset(me.area, 2, 355)) {
+		if (!Pather.moveToExit(49, true, Config.ClearPath) || !Pather.moveToPreset(me.area, 2, 355, 0, 0, Config.ClearPath)) {
 			throw new Error();
 		}
 
@@ -99,7 +99,7 @@ function Questing() {
 
 		Precast.doPrecast(true);
 
-		if (!Pather.moveToPreset(105, 1, 256)) {
+		if (!Pather.moveToPreset(105, 1, 256, 0, 0, Config.ClearPath)) {
 			return false;
 		}
 
@@ -134,7 +134,7 @@ function Questing() {
 
 		Precast.doPrecast(true);
 
-		if (!Pather.moveToExit(94, true) || !Pather.moveToPreset(me.area, 2, 193)) {
+		if (!Pather.moveToExit(94, true, Config.ClearPath) || !Pather.moveToPreset(me.area, 2, 193, 0, 0, Config.ClearPath)) {
 			throw new Error();
 		}
 
@@ -173,7 +173,7 @@ function Questing() {
 		}
 
 		Precast.doPrecast(true);
-		Pather.moveTo(3883, 5113);
+		Pather.moveTo(3883, 5113, 3, Config.ClearPath);
 		Attack.kill(getLocaleString(22435)); // Shenk the Overseer
 		Town.goToTown();
 
@@ -199,7 +199,7 @@ function Questing() {
 
 		Precast.doPrecast(true);
 
-		if (!Pather.moveToExit(114, true) || !Pather.moveToPreset(me.area, 2, 460)) {
+		if (!Pather.moveToExit(114, true, Config.ClearPath) || !Pather.moveToPreset(me.area, 2, 460, 0, 0, Config.ClearPath)) {
 			throw new Error();
 		}
 

--- a/d2bs/kolbot/libs/bots/Radament.js
+++ b/d2bs/kolbot/libs/bots/Radament.js
@@ -9,7 +9,7 @@ function Radament() {
 	Pather.useWaypoint(48);
 	Precast.doPrecast(true);
 
-	if (!Pather.moveToExit(49, true) || !Pather.moveToPreset(me.area, 2, 355)) {
+	if (!Pather.moveToExit(49, true, Config.ClearPath) || !Pather.moveToPreset(me.area, 2, 355, 0, 0, Config.ClearPath)) {
 		throw new Error("Failed to move to Radament");
 	}
 

--- a/d2bs/kolbot/libs/bots/Rakanishu.js
+++ b/d2bs/kolbot/libs/bots/Rakanishu.js
@@ -9,7 +9,7 @@ function Rakanishu() {
 	Pather.useWaypoint(4);
 	Precast.doPrecast(true);
 
-	if (!Pather.moveToPreset(me.area, 1, 737, 0, 0, false, true)) {
+	if (!Pather.moveToPreset(me.area, 1, 737, 0, 0, Config.ClearPath, true)) {
 		throw new Error("Failed to move to Rakanishu");
 	}
 

--- a/d2bs/kolbot/libs/bots/SharpTooth.js
+++ b/d2bs/kolbot/libs/bots/SharpTooth.js
@@ -9,7 +9,7 @@ function SharpTooth() {
 	Pather.useWaypoint(111);
 	Precast.doPrecast(true);
 
-	if (!Pather.moveToPreset(me.area, 1, 790)) {
+	if (!Pather.moveToPreset(me.area, 1, 790, 0, 0, Config.ClearPath)) {
 		throw new Error("Failed to move to Sharptooth Slayer");
 	}
 

--- a/d2bs/kolbot/libs/bots/Smith.js
+++ b/d2bs/kolbot/libs/bots/Smith.js
@@ -9,7 +9,7 @@ function Smith() {
 	Pather.useWaypoint(27);
 	Precast.doPrecast(true);
 
-	if (!Pather.moveToPreset(28, 2, 108)) {
+	if (!Pather.moveToPreset(28, 2, 108, 0, 0, Config.ClearPath)) {
 		throw new Error("Failed to move to the Smith");
 	}
 

--- a/d2bs/kolbot/libs/bots/Snapchip.js
+++ b/d2bs/kolbot/libs/bots/Snapchip.js
@@ -9,7 +9,7 @@ function Snapchip() {
 	Pather.useWaypoint(118);
 	Precast.doPrecast(true);
 
-	if (!Pather.moveToExit(119, true) || !Pather.moveToPreset(me.area, 2, 397)) {
+	if (!Pather.moveToExit(119, true, Config.ClearPath) || !Pather.moveToPreset(me.area, 2, 397, 0, 0, Config.ClearPath)) {
 		throw new Error("Failed to move to Snapchip Shatter");
 	}
 

--- a/d2bs/kolbot/libs/bots/Stormtree.js
+++ b/d2bs/kolbot/libs/bots/Stormtree.js
@@ -9,7 +9,7 @@ function Stormtree() {
 	Pather.useWaypoint(79);
 	Precast.doPrecast(true);
 
-	if (!Pather.moveToExit(78, true)) {
+	if (!Pather.moveToExit(78, true, Config.ClearPath)) {
 		throw new Error("Failed to move to Stormtree");
 	}
 

--- a/d2bs/kolbot/libs/bots/Summoner.js
+++ b/d2bs/kolbot/libs/bots/Summoner.js
@@ -21,7 +21,7 @@ function Summoner () {
 		}
 	}
 
-	if (!Pather.moveToPreset(me.area, 2, 357, -3, -3)) {
+	if (!Pather.moveToPreset(me.area, 2, 357, -3, -3, Config.ClearPath)) {
 		throw new Error("Failed to move to Summoner");
 	}
 

--- a/d2bs/kolbot/libs/bots/ThreshSocket.js
+++ b/d2bs/kolbot/libs/bots/ThreshSocket.js
@@ -9,7 +9,7 @@ function ThreshSocket() {
 	Pather.useWaypoint(112);
 	Precast.doPrecast(true);
 
-	if (!Pather.moveToExit(113, false)) {
+	if (!Pather.moveToExit(113, false, Config.ClearPath)) {
 		throw new Error("Failed to move to Thresh Socket");
 	}
 

--- a/d2bs/kolbot/libs/bots/Tombs.js
+++ b/d2bs/kolbot/libs/bots/Tombs.js
@@ -12,7 +12,7 @@ function Tombs() {
 	Precast.doPrecast(true);
 
 	for (i = 66; i <= 72; i += 1) {
-		if (!Pather.moveToExit(i, true)) {
+		if (!Pather.moveToExit(i, true, Config.ClearPath)) {
 			throw new Error("Failed to move to tomb");
 		}
 
@@ -22,7 +22,7 @@ function Tombs() {
 			Precast.doPrecast(true);
 		}
 
-		if (!Pather.moveToExit(46, true)) {
+		if (!Pather.moveToExit(46, true, Config.ClearPath)) {
 			throw new Error("Failed to move to Canyon");
 		}
 	}

--- a/d2bs/kolbot/libs/bots/Treehead.js
+++ b/d2bs/kolbot/libs/bots/Treehead.js
@@ -9,7 +9,7 @@ function Treehead() {
 	Pather.useWaypoint(5);
 	Precast.doPrecast(true);
 
-	if (!Pather.moveToPreset(me.area, 2, 30, 5, 5)) {
+	if (!Pather.moveToPreset(me.area, 2, 30, 5, 5, Config.ClearPath)) {
 		throw new Error("Failed to move to Treehead");
 	}
 

--- a/d2bs/kolbot/libs/bots/UndergroundPassage.js
+++ b/d2bs/kolbot/libs/bots/UndergroundPassage.js
@@ -9,7 +9,7 @@ function UndergroundPassage() {
 	Pather.useWaypoint(4);
 	Precast.doPrecast(true);
 
-	if (!Pather.moveToExit([10, 14], true)) {
+	if (!Pather.moveToExit([10, 14], true, Config.ClearPath)) {
 		throw new Error("Failed to move to Underground passage level 2");
 	}
 

--- a/d2bs/kolbot/libs/common/Config.js
+++ b/d2bs/kolbot/libs/common/Config.js
@@ -405,18 +405,25 @@ var Config = {
 		EntranceTP: "Entrance TP up",
 		StarTP: "Star TP up",
 		DiabloMsg: "Diablo",
-		WalkClear: false
+		WalkClear: false,
+		SealOrder: ["vizier", "seis", "infector"],
 	},
 	DiabloHelper: {
 		Wait: 120,
 		Entrance: false,
 		SkipIfBaal: false,
-		SkipTP: false
+		SkipTP: false,
+		OpenSeals: false,
+		SafePrecast: true,
+		SealOrder: ["vizier", "seis", "infector"],
 	},
 	BattleOrders: {
 		Mode: 0,
 		Getters: [],
-		Wait: false
+		Idle: false,  // Idle until player receiving BO leaves
+		QuitOnFailure: false,  // Quit the game if BO fails
+		SkipIfTardy: true,  // Proceed with scripts if other players already moved on from BO spot
+		Wait: 10,  // Duration to wait for players to join game
 	},
 	Enchant: {
 		Triggers: ["chant", "cows", "wps"],

--- a/d2bs/kolbot/libs/config/Amazon.js
+++ b/d2bs/kolbot/libs/config/Amazon.js
@@ -509,6 +509,7 @@ function LoadConfig() {
 	Config.DodgeHP = 100; // Dodge only if HP percent is less than or equal to Config.DodgeHP. 100 = always dodge.
 	Config.BossPriority = false; // Set to true to attack Unique/SuperUnique monsters first when clearing
 	Config.ClearType = 0xF; // Monster spectype to kill in level clear scripts (ie. Mausoleum). 0xF = skip normal, 0x7 = champions/bosses, 0 = all
+	Config.ClearPath = false; // Set to true to clear path while traveling
 	Config.TeleStomp = false; // Use merc to attack bosses if they're immune to attacks, but not to physical damage
 
 	// Wereform setup. Make sure you read Templates/Attacks.txt for attack skill format.

--- a/d2bs/kolbot/libs/config/Amazon.js
+++ b/d2bs/kolbot/libs/config/Amazon.js
@@ -19,8 +19,11 @@ function LoadConfig() {
 	// Battle orders script - Use this for 2+ characters (for example BO barb + sorc)
 	Scripts.BattleOrders = false;
 		Config.BattleOrders.Mode = 0; // 0 = give BO, 1 = get BO
-		Config.BattleOrders.Wait = false; // Idle until the player that received BO leaves.
+		Config.BattleOrders.Idle = false; // Idle until the player that received BO leaves.
 		Config.BattleOrders.Getters = []; // List of players to wait for before casting Battle Orders (mode 0). All players must be in the same area as the BOer.
+		Config.BattleOrders.QuitOnFailure = false;  // Quit the game if BO fails
+		Config.BattleOrders.SkipIfTardy = true;  // Proceed with scripts if other players already moved on from BO spot
+		Config.BattleOrders.Wait = 10;  // Duration to wait for players to join game in seconds (default: 10)
 
 	// Team MF system
 	Config.MFLeader = false; // Set to true if you have one or more MFHelpers. Opens TP and gives commands when doing normal MF runs.
@@ -88,6 +91,7 @@ function LoadConfig() {
 		Config.Diablo.EntranceTP = "Entrance TP up";
 		Config.Diablo.StarTP = "Star TP up";
 		Config.Diablo.DiabloMsg = "Diablo";
+		Config.Diablo.SealOrder = ["vizier", "seis", "infector"]; // the order in which to clear the seals. If seals are excluded, they won't be checked unless diablo fails to appear
 	Scripts.SealLeader = false; // Clear a safe spot around seals and invite leechers in. Leechers should run SealLeecher script. Don't run with Diablo or FastDiablo.
 
 	// *** act 5 ***
@@ -141,6 +145,9 @@ function LoadConfig() {
 		Config.DiabloHelper.Entrance = true; // Start from entrance. Set to false to start from star.
 		Config.DiabloHelper.SkipTP = false; // Don't wait for town portal and directly head to chaos. It will clear monsters around chaos entrance and wait for the runner.
 		Config.DiabloHelper.SkipIfBaal = false; // End script if there are party members in a Baal run.
+		Config.DiabloHelper.OpenSeals = false; // Open seals as the helper
+		Config.DiabloHelper.SafePrecast = true; // take random WP to safely precast
+		Config.DiabloHelper.SealOrder = ["vizier", "seis", "infector"]; // the order in which to clear the seals. If seals are excluded, they won't be checked unless diablo fails to appear
 	Scripts.AutoBaal = false; // Baal leecher with auto leader assignment
 		Config.AutoBaal.FindShrine = false; // false = disabled, 1 = search after hot tp message, 2 = search as soon as leader is found
 		Config.AutoBaal.LeechSpot = [15115, 5050]; // X, Y coords of Throne Room leech spot

--- a/d2bs/kolbot/libs/config/Assassin.js
+++ b/d2bs/kolbot/libs/config/Assassin.js
@@ -510,6 +510,7 @@ function LoadConfig() {
 	Config.DodgeHP = 100; // Dodge only if HP percent is less than or equal to Config.DodgeHP. 100 = always dodge.
 	Config.BossPriority = false; // Set to true to attack Unique/SuperUnique monsters first when clearing
 	Config.ClearType = 0xF; // Monster spectype to kill in level clear scripts (ie. Mausoleum). 0xF = skip normal, 0x7 = champions/bosses, 0 = all
+	Config.ClearPath = false; // Set to true to clear path while traveling
 
 	// Wereform setup. Make sure you read Templates/Attacks.txt for attack skill format.
 	Config.Wereform = false; // 0 / false - don't shapeshift, 1 / "Werewolf" - change to werewolf, 2 / "Werebear" - change to werebear

--- a/d2bs/kolbot/libs/config/Assassin.js
+++ b/d2bs/kolbot/libs/config/Assassin.js
@@ -19,8 +19,11 @@ function LoadConfig() {
 	// Battle orders script - Use this for 2+ characters (for example BO barb + sorc)
 	Scripts.BattleOrders = false;
 		Config.BattleOrders.Mode = 0; // 0 = give BO, 1 = get BO
-		Config.BattleOrders.Wait = false; // Idle until the player that received BO leaves.
+		Config.BattleOrders.Idle = false; // Idle until the player that received BO leaves.
 		Config.BattleOrders.Getters = []; // List of players to wait for before casting Battle Orders (mode 0). All players must be in the same area as the BOer.
+		Config.BattleOrders.QuitOnFailure = false;  // Quit the game if BO fails
+		Config.BattleOrders.SkipIfTardy = true;  // Proceed with scripts if other players already moved on from BO spot
+		Config.BattleOrders.Wait = 10;  // Duration to wait for players to join game in seconds (default: 10)
 
 	// Team MF system
 	Config.MFLeader = false; // Set to true if you have one or more MFHelpers. Opens TP and gives commands when doing normal MF runs.
@@ -88,6 +91,7 @@ function LoadConfig() {
 		Config.Diablo.EntranceTP = "Entrance TP up";
 		Config.Diablo.StarTP = "Star TP up";
 		Config.Diablo.DiabloMsg = "Diablo";
+		Config.Diablo.SealOrder = ["vizier", "seis", "infector"]; // the order in which to clear the seals. If seals are excluded, they won't be checked unless diablo fails to appear
 	Scripts.SealLeader = false; // Clear a safe spot around seals and invite leechers in. Leechers should run SealLeecher script. Don't run with Diablo or FastDiablo.
 
 	// *** act 5 ***
@@ -141,6 +145,9 @@ function LoadConfig() {
 		Config.DiabloHelper.Entrance = true; // Start from entrance. Set to false to start from star.
 		Config.DiabloHelper.SkipTP = false; // Don't wait for town portal and directly head to chaos. It will clear monsters around chaos entrance and wait for the runner.
 		Config.DiabloHelper.SkipIfBaal = false; // End script if there are party members in a Baal run.
+		Config.DiabloHelper.OpenSeals = false; // Open seals as the helper
+		Config.DiabloHelper.SafePrecast = true; // take random WP to safely precast
+		Config.DiabloHelper.SealOrder = ["vizier", "seis", "infector"]; // the order in which to clear the seals. If seals are excluded, they won't be checked unless diablo fails to appear
 	Scripts.AutoBaal = false; // Baal leecher with auto leader assignment
 		Config.AutoBaal.FindShrine = false; // false = disabled, 1 = search after hot tp message, 2 = search as soon as leader is found
 		Config.AutoBaal.LeechSpot = [15115, 5050]; // X, Y coords of Throne Room leech spot

--- a/d2bs/kolbot/libs/config/Barbarian.js
+++ b/d2bs/kolbot/libs/config/Barbarian.js
@@ -503,6 +503,7 @@ function LoadConfig() {
 
 	Config.BossPriority = false; // Set to true to attack Unique/SuperUnique monsters first when clearing
 	Config.ClearType = 0xF; // Monster spectype to kill in level clear scripts (ie. Mausoleum). 0xF = skip normal, 0x7 = champions/bosses, 0 = all
+	Config.ClearPath = false; // Set to true to clear path while traveling
 
 	// Wereform setup. Make sure you read Templates/Attacks.txt for attack skill format.
 	Config.Wereform = false; // 0 / false - don't shapeshift, 1 / "Werewolf" - change to werewolf, 2 / "Werebear" - change to werebear

--- a/d2bs/kolbot/libs/config/Barbarian.js
+++ b/d2bs/kolbot/libs/config/Barbarian.js
@@ -19,8 +19,11 @@ function LoadConfig() {
 	// Battle orders script - Use this for 2+ characters (for example BO barb + sorc)
 	Scripts.BattleOrders = false;
 		Config.BattleOrders.Mode = 0; // 0 = give BO, 1 = get BO
-		Config.BattleOrders.Wait = false; // Idle until the player that received BO leaves.
+		Config.BattleOrders.Idle = false; // Idle until the player that received BO leaves.
 		Config.BattleOrders.Getters = []; // List of players to wait for before casting Battle Orders (mode 0). All players must be in the same area as the BOer.
+		Config.BattleOrders.QuitOnFailure = false;  // Quit the game if BO fails
+		Config.BattleOrders.SkipIfTardy = true;  // Proceed with scripts if other players already moved on from BO spot
+		Config.BattleOrders.Wait = 10;  // Duration to wait for players to join game in seconds (default: 10)
 
 	// Team MF system
 	Config.MFLeader = false; // Set to true if you have one or more MFHelpers. Opens TP and gives commands when doing normal MF runs.
@@ -88,6 +91,7 @@ function LoadConfig() {
 		Config.Diablo.EntranceTP = "Entrance TP up";
 		Config.Diablo.StarTP = "Star TP up";
 		Config.Diablo.DiabloMsg = "Diablo";
+		Config.Diablo.SealOrder = ["vizier", "seis", "infector"]; // the order in which to clear the seals. If seals are excluded, they won't be checked unless diablo fails to appear
 	Scripts.SealLeader = false; // Clear a safe spot around seals and invite leechers in. Leechers should run SealLeecher script. Don't run with Diablo or FastDiablo.
 
 	// *** act 5 ***
@@ -141,6 +145,9 @@ function LoadConfig() {
 		Config.DiabloHelper.Entrance = true; // Start from entrance. Set to false to start from star.
 		Config.DiabloHelper.SkipTP = false; // Don't wait for town portal and directly head to chaos. It will clear monsters around chaos entrance and wait for the runner.
 		Config.DiabloHelper.SkipIfBaal = false; // End script if there are party members in a Baal run.
+		Config.DiabloHelper.OpenSeals = false; // Open seals as the helper
+		Config.DiabloHelper.SafePrecast = true; // take random WP to safely precast
+		Config.DiabloHelper.SealOrder = ["vizier", "seis", "infector"]; // the order in which to clear the seals. If seals are excluded, they won't be checked unless diablo fails to appear
 	Scripts.AutoBaal = false; // Baal leecher with auto leader assignment
 		Config.AutoBaal.FindShrine = false; // false = disabled, 1 = search after hot tp message, 2 = search as soon as leader is found
 		Config.AutoBaal.LeechSpot = [15115, 5050]; // X, Y coords of Throne Room leech spot

--- a/d2bs/kolbot/libs/config/Druid.js
+++ b/d2bs/kolbot/libs/config/Druid.js
@@ -19,8 +19,11 @@ function LoadConfig() {
 	// Battle orders script - Use this for 2+ characters (for example BO barb + sorc)
 	Scripts.BattleOrders = false;
 		Config.BattleOrders.Mode = 0; // 0 = give BO, 1 = get BO
-		Config.BattleOrders.Wait = false; // Idle until the player that received BO leaves.
+		Config.BattleOrders.Idle = false; // Idle until the player that received BO leaves.
 		Config.BattleOrders.Getters = []; // List of players to wait for before casting Battle Orders (mode 0). All players must be in the same area as the BOer.
+		Config.BattleOrders.QuitOnFailure = false;  // Quit the game if BO fails
+		Config.BattleOrders.SkipIfTardy = true;  // Proceed with scripts if other players already moved on from BO spot
+		Config.BattleOrders.Wait = 10;  // Duration to wait for players to join game in seconds (default: 10)tleOrders.Getters = []; // List of players to wait for before casting Battle Orders (mode 0). All players must be in the same area as the BOer.
 
 	// Team MF system
 	Config.MFLeader = false; // Set to true if you have one or more MFHelpers. Opens TP and gives commands when doing normal MF runs.
@@ -88,6 +91,7 @@ function LoadConfig() {
 		Config.Diablo.EntranceTP = "Entrance TP up";
 		Config.Diablo.StarTP = "Star TP up";
 		Config.Diablo.DiabloMsg = "Diablo";
+		Config.Diablo.SealOrder = ["vizier", "seis", "infector"]; // the order in which to clear the seals. If seals are excluded, they won't be checked unless diablo fails to appear
 	Scripts.SealLeader = false; // Clear a safe spot around seals and invite leechers in. Leechers should run SealLeecher script. Don't run with Diablo or FastDiablo.
 
 	// *** act 5 ***
@@ -141,6 +145,9 @@ function LoadConfig() {
 		Config.DiabloHelper.Entrance = true; // Start from entrance. Set to false to start from star.
 		Config.DiabloHelper.SkipTP = false; // Don't wait for town portal and directly head to chaos. It will clear monsters around chaos entrance and wait for the runner.
 		Config.DiabloHelper.SkipIfBaal = false; // End script if there are party members in a Baal run.
+		Config.DiabloHelper.OpenSeals = false; // Open seals as the helper
+		Config.DiabloHelper.SafePrecast = true; // take random WP to safely precast
+		Config.DiabloHelper.SealOrder = ["vizier", "seis", "infector"]; // the order in which to clear the seals. If seals are excluded, they won't be checked unless diablo fails to appear
 	Scripts.AutoBaal = false; // Baal leecher with auto leader assignment
 		Config.AutoBaal.FindShrine = false; // false = disabled, 1 = search after hot tp message, 2 = search as soon as leader is found
 		Config.AutoBaal.LeechSpot = [15115, 5050]; // X, Y coords of Throne Room leech spot

--- a/d2bs/kolbot/libs/config/Druid.js
+++ b/d2bs/kolbot/libs/config/Druid.js
@@ -506,6 +506,7 @@ function LoadConfig() {
 
 	Config.BossPriority = false; // Set to true to attack Unique/SuperUnique monsters first when clearing
 	Config.ClearType = 0xF; // Monster spectype to kill in level clear scripts (ie. Mausoleum). 0xF = skip normal, 0x7 = champions/bosses, 0 = all
+	Config.ClearPath = false; // Set to true to clear path while traveling
 	Config.TeleStomp = false; // Use merc to attack bosses if they're immune to attacks, but not to physical damage
 
 	// Wereform setup. Make sure you read Templates/Attacks.txt for attack skill format.

--- a/d2bs/kolbot/libs/config/Necromancer.js
+++ b/d2bs/kolbot/libs/config/Necromancer.js
@@ -509,6 +509,7 @@ function LoadConfig() {
 	Config.DodgeHP = 100; // Dodge only if HP percent is less than or equal to Config.DodgeHP. 100 = always dodge.
 	Config.BossPriority = false; // Set to true to attack Unique/SuperUnique monsters first when clearing
 	Config.ClearType = 0xF; // Monster spectype to kill in level clear scripts (ie. Mausoleum). 0xF = skip normal, 0x7 = champions/bosses, 0 = all
+	Config.ClearPath = false; // Set to true to clear path while traveling
 	Config.TeleStomp = false; // Use merc to attack bosses if they're immune to attacks, but not to physical damage
 
 	// Wereform setup. Make sure you read Templates/Attacks.txt for attack skill format.

--- a/d2bs/kolbot/libs/config/Necromancer.js
+++ b/d2bs/kolbot/libs/config/Necromancer.js
@@ -19,8 +19,11 @@ function LoadConfig() {
 	// Battle orders script - Use this for 2+ characters (for example BO barb + sorc)
 	Scripts.BattleOrders = false;
 		Config.BattleOrders.Mode = 0; // 0 = give BO, 1 = get BO
-		Config.BattleOrders.Wait = false; // Idle until the player that received BO leaves.
+		Config.BattleOrders.Idle = false; // Idle until the player that received BO leaves.
 		Config.BattleOrders.Getters = []; // List of players to wait for before casting Battle Orders (mode 0). All players must be in the same area as the BOer.
+		Config.BattleOrders.QuitOnFailure = false;  // Quit the game if BO fails
+		Config.BattleOrders.SkipIfTardy = true;  // Proceed with scripts if other players already moved on from BO spot
+		Config.BattleOrders.Wait = 10;  // Duration to wait for players to join game in seconds (default: 10)
 
 	// Team MF system
 	Config.MFLeader = false; // Set to true if you have one or more MFHelpers. Opens TP and gives commands when doing normal MF runs.
@@ -88,6 +91,7 @@ function LoadConfig() {
 		Config.Diablo.EntranceTP = "Entrance TP up";
 		Config.Diablo.StarTP = "Star TP up";
 		Config.Diablo.DiabloMsg = "Diablo";
+		Config.Diablo.SealOrder = ["vizier", "seis", "infector"]; // the order in which to clear the seals. If seals are excluded, they won't be checked unless diablo fails to appear
 	Scripts.SealLeader = false; // Clear a safe spot around seals and invite leechers in. Leechers should run SealLeecher script. Don't run with Diablo or FastDiablo.
 
 	// *** act 5 ***
@@ -141,6 +145,9 @@ function LoadConfig() {
 		Config.DiabloHelper.Entrance = true; // Start from entrance. Set to false to start from star.
 		Config.DiabloHelper.SkipTP = false; // Don't wait for town portal and directly head to chaos. It will clear monsters around chaos entrance and wait for the runner.
 		Config.DiabloHelper.SkipIfBaal = false; // End script if there are party members in a Baal run.
+		Config.DiabloHelper.OpenSeals = false; // Open seals as the helper
+		Config.DiabloHelper.SafePrecast = true; // take random WP to safely precast
+		Config.DiabloHelper.SealOrder = ["vizier", "seis", "infector"]; // the order in which to clear the seals. If seals are excluded, they won't be checked unless diablo fails to appear
 	Scripts.AutoBaal = false; // Baal leecher with auto leader assignment
 		Config.AutoBaal.FindShrine = false; // false = disabled, 1 = search after hot tp message, 2 = search as soon as leader is found
 		Config.AutoBaal.LeechSpot = [15115, 5050]; // X, Y coords of Throne Room leech spot

--- a/d2bs/kolbot/libs/config/Paladin.js
+++ b/d2bs/kolbot/libs/config/Paladin.js
@@ -19,8 +19,11 @@ function LoadConfig() {
 	// Battle orders script - Use this for 2+ characters (for example BO barb + sorc)
 	Scripts.BattleOrders = false;
 		Config.BattleOrders.Mode = 0; // 0 = give BO, 1 = get BO
-		Config.BattleOrders.Wait = false; // Idle until the player that received BO leaves.
+		Config.BattleOrders.Idle = false; // Idle until the player that received BO leaves.
 		Config.BattleOrders.Getters = []; // List of players to wait for before casting Battle Orders (mode 0). All players must be in the same area as the BOer.
+		Config.BattleOrders.QuitOnFailure = false;  // Quit the game if BO fails
+		Config.BattleOrders.SkipIfTardy = true;  // Proceed with scripts if other players already moved on from BO spot
+		Config.BattleOrders.Wait = 10;  // Duration to wait for players to join game in seconds (default: 10)
 
 	// Team MF system
 	Config.MFLeader = false; // Set to true if you have one or more MFHelpers. Opens TP and gives commands when doing normal MF runs.
@@ -88,6 +91,7 @@ function LoadConfig() {
 		Config.Diablo.EntranceTP = "Entrance TP up";
 		Config.Diablo.StarTP = "Star TP up";
 		Config.Diablo.DiabloMsg = "Diablo";
+		Config.Diablo.SealOrder = ["vizier", "seis", "infector"]; // the order in which to clear the seals. If seals are excluded, they won't be checked unless diablo fails to appear
 	Scripts.SealLeader = false; // Clear a safe spot around seals and invite leechers in. Leechers should run SealLeecher script. Don't run with Diablo or FastDiablo.
 
 	// *** act 5 ***
@@ -141,6 +145,9 @@ function LoadConfig() {
 		Config.DiabloHelper.Entrance = true; // Start from entrance. Set to false to start from star.
 		Config.DiabloHelper.SkipTP = false; // Don't wait for town portal and directly head to chaos. It will clear monsters around chaos entrance and wait for the runner.
 		Config.DiabloHelper.SkipIfBaal = false; // End script if there are party members in a Baal run.
+		Config.DiabloHelper.OpenSeals = false; // Open seals as the helper
+		Config.DiabloHelper.SafePrecast = true; // take random WP to safely precast
+		Config.DiabloHelper.SealOrder = ["vizier", "seis", "infector"]; // the order in which to clear the seals. If seals are excluded, they won't be checked unless diablo fails to appear
 	Scripts.AutoBaal = false; // Baal leecher with auto leader assignment
 		Config.AutoBaal.FindShrine = false; // false = disabled, 1 = search after hot tp message, 2 = search as soon as leader is found
 		Config.AutoBaal.LeechSpot = [15115, 5050]; // X, Y coords of Throne Room leech spot

--- a/d2bs/kolbot/libs/config/Paladin.js
+++ b/d2bs/kolbot/libs/config/Paladin.js
@@ -506,6 +506,7 @@ function LoadConfig() {
 
 	Config.BossPriority = false; // Set to true to attack Unique/SuperUnique monsters first when clearing
 	Config.ClearType = 0xF; // Monster spectype to kill in level clear scripts (ie. Mausoleum). 0xF = skip normal, 0x7 = champions/bosses, 0 = all
+	Config.ClearPath = false; // Set to true to clear path while traveling
 
 	// Wereform setup. Make sure you read Templates/Attacks.txt for attack skill format.
 	Config.Wereform = false; // 0 / false - don't shapeshift, 1 / "Werewolf" - change to werewolf, 2 / "Werebear" - change to werebear

--- a/d2bs/kolbot/libs/config/Sorceress.js
+++ b/d2bs/kolbot/libs/config/Sorceress.js
@@ -510,6 +510,7 @@ function LoadConfig() {
 	Config.DodgeHP = 100; // Dodge only if HP percent is less than or equal to Config.DodgeHP. 100 = always dodge.
 	Config.BossPriority = false; // Set to true to attack Unique/SuperUnique monsters first when clearing
 	Config.ClearType = 0xF; // Monster spectype to kill in level clear scripts (ie. Mausoleum). 0xF = skip normal, 0x7 = champions/bosses, 0 = all
+	Config.ClearPath = false; // Set to true to clear path while traveling
 	Config.TeleStomp = false; // Use merc to attack bosses if they're immune to attacks, but not to physical damage
 
 	// Wereform setup. Make sure you read Templates/Attacks.txt for attack skill format.

--- a/d2bs/kolbot/libs/config/Sorceress.js
+++ b/d2bs/kolbot/libs/config/Sorceress.js
@@ -19,8 +19,11 @@ function LoadConfig() {
 	// Battle orders script - Use this for 2+ characters (for example BO barb + sorc)
 	Scripts.BattleOrders = false;
 		Config.BattleOrders.Mode = 0; // 0 = give BO, 1 = get BO
-		Config.BattleOrders.Wait = false; // Idle until the player that received BO leaves.
+		Config.BattleOrders.Idle = false; // Idle until the player that received BO leaves.
 		Config.BattleOrders.Getters = []; // List of players to wait for before casting Battle Orders (mode 0). All players must be in the same area as the BOer.
+		Config.BattleOrders.QuitOnFailure = false;  // Quit the game if BO fails
+		Config.BattleOrders.SkipIfTardy = true;  // Proceed with scripts if other players already moved on from BO spot
+		Config.BattleOrders.Wait = 10;  // Duration to wait for players to join game in seconds (default: 10)
 
 	// Team MF system
 	Config.MFLeader = false; // Set to true if you have one or more MFHelpers. Opens TP and gives commands when doing normal MF runs.
@@ -88,6 +91,7 @@ function LoadConfig() {
 		Config.Diablo.EntranceTP = "Entrance TP up";
 		Config.Diablo.StarTP = "Star TP up";
 		Config.Diablo.DiabloMsg = "Diablo";
+		Config.Diablo.SealOrder = ["vizier", "seis", "infector"]; // the order in which to clear the seals. If seals are excluded, they won't be checked unless diablo fails to appear
 	Scripts.SealLeader = false; // Clear a safe spot around seals and invite leechers in. Leechers should run SealLeecher script. Don't run with Diablo or FastDiablo.
 
 	// *** act 5 ***
@@ -141,6 +145,9 @@ function LoadConfig() {
 		Config.DiabloHelper.Entrance = true; // Start from entrance. Set to false to start from star.
 		Config.DiabloHelper.SkipTP = false; // Don't wait for town portal and directly head to chaos. It will clear monsters around chaos entrance and wait for the runner.
 		Config.DiabloHelper.SkipIfBaal = false; // End script if there are party members in a Baal run.
+		Config.DiabloHelper.OpenSeals = false; // Open seals as the helper
+		Config.DiabloHelper.SafePrecast = true; // take random WP to safely precast
+		Config.DiabloHelper.SealOrder = ["vizier", "seis", "infector"]; // the order in which to clear the seals. If seals are excluded, they won't be checked unless diablo fails to appear
 	Scripts.AutoBaal = false; // Baal leecher with auto leader assignment
 		Config.AutoBaal.FindShrine = false; // false = disabled, 1 = search after hot tp message, 2 = search as soon as leader is found
 		Config.AutoBaal.LeechSpot = [15115, 5050]; // X, Y coords of Throne Room leech spot


### PR DESCRIPTION
This config var already exists but scripts weren't written to check the
var when traveling. Now they will clear while traveling, if Config.ClearPath is set to true

While traveling, chars that don't teleport often get blocked and end up exceeding the retry amount set and exiting the script with "failed to travel to x". Setting `Config.ClearPath = true;` will solve that sort of problem, as the bot will clear enemies blocking the path.