### PR TITLE
Speed up NTIP

### DIFF
--- a/d2bs/kolbot/libs/NTItemParser.dbl
+++ b/d2bs/kolbot/libs/NTItemParser.dbl
@@ -589,7 +589,7 @@ NTIP.ParseLineInt = function (input, info) {
 		tmp = p_result[i];
 		if (p_result[i].length) {
 			try {
-				p_result[i] = (new Function('return item =>' + p_result[i] + ';')).call(null); // generate function out of
+				p_result[i] = (new Function('return function(item) { return ' + p_result[i] + ';}')).call(null); // generate function out of
 			} catch(e) {
 				Misc.errorReport("ÿc1Pickit error! Line # ÿc2" + info.line + " ÿc1Entry: ÿc0" + info.string + " (" + info.file + ") Error message: " + e.message);
 

--- a/d2bs/kolbot/libs/NTItemParser.dbl
+++ b/d2bs/kolbot/libs/NTItemParser.dbl
@@ -208,21 +208,24 @@ NTIP.CheckItem = function (item, entryList, verbose) {
 
 	identified = item.getFlag(0x10);
 
-	for (i = 0; i < list.length; i += 1) {
+	for (i = 0; i < list.length; i++) {
 		try {
-			if (list[i][0].length > 0) {
-				if (eval(list[i][0])) {
-					if (list[i][1].length > 0) {
-						if (eval(list[i][1])) {
-							if (list[i][2] && list[i][2].MaxQuantity && !isNaN(list[i][2].MaxQuantity)) {
-								num = NTIP.CheckQuantityOwned(list[i][0], list[i][1]);
+			// Get the values in separated variables (its faster)
+			const [type, stat, wanted] = list[i];
 
-								if (num < list[i][2].MaxQuantity) {
+			if (typeof type === 'function') {
+				if (type(item)) {
+					if (typeof stat === 'function') {
+						if (stat(item)) {
+							if (wanted && wanted.MaxQuantity && !isNaN(wanted.MaxQuantity)) {
+								num = NTIP.CheckQuantityOwned(type, stat);
+
+								if (num < wanted.MaxQuantity) {
 									result = 1;
 
 									break;
 								} else {
-									if (item.getParent() && item.getParent().name === me.name && item.mode === 0 && num === list[i][2].MaxQuantity) { // attempt at inv fix for maxquantity
+									if (item.getParent() && item.getParent().name === me.name && item.mode === 0 && num === wanted.MaxQuantity) { // attempt at inv fix for maxquantity
 										result = 1;
 
 										break;
@@ -241,15 +244,15 @@ NTIP.CheckItem = function (item, entryList, verbose) {
 							}
 						}
 					} else {
-						if (list[i][2] && list[i][2].MaxQuantity && !isNaN(list[i][2].MaxQuantity)) {
-							num = NTIP.CheckQuantityOwned(list[i][0], null);
+						if (wanted && wanted.MaxQuantity && !isNaN(wanted.MaxQuantity)) {
+							num = NTIP.CheckQuantityOwned(type, null);
 
-							if (num < list[i][2].MaxQuantity) {
+							if (num < wanted.MaxQuantity) {
 								result = 1;
 
 								break;
 							} else {
-								if (item.getParent() && item.getParent().name === me.name && item.mode === 0 && num === list[i][2].MaxQuantity) { // attempt at inv fix for maxquantity
+								if (item.getParent() && item.getParent().name === me.name && item.mode === 0 && num === wanted.MaxQuantity) { // attempt at inv fix for maxquantity
 									result = 1;
 
 									break;
@@ -262,17 +265,17 @@ NTIP.CheckItem = function (item, entryList, verbose) {
 						}
 					}
 				}
-			} else if (list[i][1].length > 0) {
-				if (eval(list[i][1])) {
-					if (list[i][2] && list[i][2].MaxQuantity && !isNaN(list[i][2].MaxQuantity)) {
-						num = NTIP.CheckQuantityOwned(null, list[i][1]);
+			} else if (typeof stat === 'function') {
+				if (stat(item)) {
+					if (wanted && wanted.MaxQuantity && !isNaN(wanted.MaxQuantity)) {
+						num = NTIP.CheckQuantityOwned(null, stat);
 
-						if (num < list[i][2].MaxQuantity) {
+						if (num < wanted.MaxQuantity) {
 							result = 1;
 
 							break;
 						} else {
-							if (item.getParent() && item.getParent().name === me.name && item.mode === 0 && num === list[i][2].MaxQuantity) { // attempt at inv fix for maxquantity
+							if (item.getParent() && item.getParent().name === me.name && item.mode === 0 && num === wanted.MaxQuantity) { // attempt at inv fix for maxquantity
 								result = 1;
 
 								break;
@@ -297,7 +300,7 @@ NTIP.CheckItem = function (item, entryList, verbose) {
 			if (!entryList) {
 				Misc.errorReport("ÿc1Pickit error! Line # ÿc2" + stringArray[i].line + " ÿc1Entry: ÿc0" + stringArray[i].string + " (" + stringArray[i].file + ") Error message: " + pickError.message + " Trigger item: " + item.fname.split("\n").reverse().join(" "));
 
-				NTIP_CheckList[i] = ["", "", ""]; // make the bad entry blank
+				NTIP_CheckList.splice(i,1); // Remove the element from the list
 			} else {
 				Misc.errorReport("ÿc1Pickit error in runeword config!");
 			}
@@ -581,6 +584,21 @@ NTIP.ParseLineInt = function (input, info) {
 			}
 		}
 	}
+	// Compile the line, to 1) remove the eval lines, and 2) increase the speed
+	for (let i = 0,tmp; i < 2; i++) {
+		tmp = p_result[i];
+		if (p_result[i].length) {
+			try {
+				p_result[i] = (new Function('return item =>' + p_result[i] + ';')).call(null); // generate function out of
+			} catch(e) {
+				Misc.errorReport("ÿc1Pickit error! Line # ÿc2" + info.line + " ÿc1Entry: ÿc0" + info.string + " (" + info.file + ") Error message: " + e.message);
 
+				return null ; // failed load this line so return false
+			}
+		} else {
+			p_result[i] = undefined;
+		}
+
+	}
 	return p_result;
 };

--- a/d2bs/kolbot/libs/NTItemParser.dbl
+++ b/d2bs/kolbot/libs/NTItemParser.dbl
@@ -183,15 +183,21 @@ NTIP.generateTierFunc = function (type) {
 						if (wanted(item)) {
 							if (typeof stat === 'function') {
 								if (stat(item)) {
-									tier = wanted[type];
+									if (wanted[type] > tier) {
+										tier = wanted[type];
+									}
 								}
 							} else {
-								tier = wanted[type];
+								if (wanted[type] > tier) {
+									tier = wanted[type];
+								}
 							}
 						}
 					} else if (typeof stat === 'function') {
 						if (stat(item)) {
-							tier = wanted[type];
+							if (wanted[type] > tier) {
+								tier = wanted[type];
+							}
 						}
 					}
 				} catch (e) {

--- a/d2bs/kolbot/libs/NTItemParser.dbl
+++ b/d2bs/kolbot/libs/NTItemParser.dbl
@@ -164,7 +164,9 @@ NTIP.generateTierFunc = function (type) {
 		var i,
 			tier = -1;
 
-		if (NTIP_QuestItems.indexOf(item.classid) > -1) return 0;
+		if (NTIP_QuestItems.indexOf(item.classid) > -1) {
+			return 0;
+		}
 
 		// Go through ALL lines that describe the item
 		for (i = 0; i < NTIP_CheckList.length; i += 1) {

--- a/d2bs/kolbot/libs/NTItemParser.dbl
+++ b/d2bs/kolbot/libs/NTItemParser.dbl
@@ -157,27 +157,54 @@ NTIP.Clear = function () {
 	stringArray = [];
 };
 
-NTIP.GetTier = function (item) {
-	let i, tier = 0;
 
-	return NTIP_CheckList
-		.filter(check => check.length === 3
-			&& check[2].hasOwnProperty('Tier')
-			&& !isNaN(check[2])
-		) // Only the valid ones
-		.reduce(function (acc,check) {
-			try {
-				for (let i = 0; i < 2; i++) {
-					// If check[i] has a length, call it, if tier is higher as current tier
-					if (typeof check[i] === 'function' && check[i](item) && check[2].Tier > acc) {
-						return check[2].Tier; // set the highest current tier
-					}
-				}
-			} catch (e) {
-				// Dont care
+/** @return {function({Unit} item)} */
+NTIP.generateTierFunc = function (type) {
+	return function (item) {
+		var i,
+			tier = -1;
+
+		if (NTIP_QuestItems.indexOf(item.classid) > -1) return 0;
+
+		// Go through ALL lines that describe the item
+		for (i = 0; i < NTIP_CheckList.length; i += 1) {
+
+			if (NTIP_CheckList[i].length !== 3) {
+				continue;
 			}
-		},0);
+
+			let [type,stat,wanted] = NTIP_CheckList[i];
+			if (wanted.hasOwnProperty(type) && wanted[type]) {
+
+				try {
+					if (typeof wanted === 'function') {
+						if (wanted(item)) {
+							if (typeof stat === 'function') {
+								if (stat(item)) {
+									tier = wanted[type];
+								}
+							} else {
+								tier = wanted[type];
+							}
+						}
+					} else if (typeof stat === 'function') {
+						if (stat(item)) {
+							tier = wanted[type];
+						}
+					}
+				} catch (e) {
+
+				}
+			}
+		}
+
+		return tier;
+	};
 };
+
+/**@function
+ * @param item */
+NTIP.GetTier = NTIP.generateTierFunc('Tier');
 
 NTIP.CheckItem = function (item, entryList, verbose) {
 	var i, list, identified, num,

--- a/d2bs/kolbot/libs/NTItemParser.dbl
+++ b/d2bs/kolbot/libs/NTItemParser.dbl
@@ -158,41 +158,25 @@ NTIP.Clear = function () {
 };
 
 NTIP.GetTier = function (item) {
-	var i,
-		tier = 0;
+	let i, tier = 0;
 
-	// Go through ALL lines that describe the item
-	for (i = 0; i < NTIP_CheckList.length; i += 1) {
-		if (NTIP_CheckList[i].length === 3 && NTIP_CheckList[i][2].hasOwnProperty("Tier") && !isNaN(NTIP_CheckList[i][2].Tier)) {
+	return NTIP_CheckList
+		.filter(check => check.length === 3
+			&& check[2].hasOwnProperty('Tier')
+			&& !isNaN(check[2])
+		) // Only the valid ones
+		.reduce(function (acc,check) {
 			try {
-				if (NTIP_CheckList[i][0].length > 0) {
-					if (eval(NTIP_CheckList[i][0])) {
-						if (NTIP_CheckList[i][1].length > 0) {
-							if (eval(NTIP_CheckList[i][1])) {
-								if (NTIP_CheckList[i][2].Tier > tier) {
-									tier = NTIP_CheckList[i][2].Tier;
-								}
-							}
-						} else {
-							if (NTIP_CheckList[i][2].Tier > tier) {
-								tier = NTIP_CheckList[i][2].Tier;
-							}
-						}
-					}
-				} else if (NTIP_CheckList[i][1].length > 0) {
-					if (eval(NTIP_CheckList[i][1])) {
-						if (NTIP_CheckList[i][2].Tier > tier) {
-							tier = NTIP_CheckList[i][2].Tier;
-						}
+				for (let i = 0; i < 2; i++) {
+					// If check[i] has a length, call it, if tier is higher as current tier
+					if (typeof check[i] === 'function' && check[i](item) && check[2].Tier > acc) {
+						return check[2].Tier; // set the highest current tier
 					}
 				}
 			} catch (e) {
-
+				// Dont care
 			}
-		}
-	}
-
-	return tier;
+		},0);
 };
 
 NTIP.CheckItem = function (item, entryList, verbose) {


### PR DESCRIPTION
I wrote some simple fixes in the past for NTIP, been decently tested, and it improves the speed and therefor the load of bot.

How? Quite simple, as you can see in the end of NTIP.ParseLineInt, it generates a new function for these pickit lines. This generation is just like eval itself, but is only ran once.

For the rest, instead of object key accessing it access directly a variable, which surpisingly saves another bit.

The fat arrow seems to be a bit faster in Firefox 22, yet less stable in times. Higher spikes. So i went ahead and made another commit converting it to a to an straight normal function.

Turns out, it saves about 30% in speed of parsing items. That doesnt seem like allot, but in the end, if your run a ton of bots, it saves allot of cycles. On top of that, the chance you catch a bad pickit line is increased, as written as a function directly, typos and so on will appear quicker.

Sidenote; I have tested these changes allot in the past, been running bots with it for a long time and so have other people, as i grabbed these changes i made from my own repository.

Tested them again ofcourse on regular kolton =)

How i tested the speed difference:
```javascript
	delay(3000); // give the threads and so on a bit of time to load, so its just running regularly

	const first = me.getItems()[0],
		start = getTickCount();

	for(let i =0; i<100;i++) {
		NTIP.CheckItem(first);
	}

	/*
	 10 tests, 507 lines (kolton.nip + lld.nip)

	 Time to parse the NIP files: (all numbers in miliseconds)

	                regular  | with changes
	 Kolton.nip       32        32
	 Pots.nip         15        15

	 Strangely, it doesnt seem to add time to the NIP parsing, at least, i cant measure it

	 Regular NTIP        -> 59 (low) 63 (avg) 79 (max) -> takes 0.63 ms for each item
	 With my alterations -> 31 (low) 47 (avg) 48 (max) -> takes 0.47 ms for each item

	 Chopping off about 29%, say 30% of the time it is calculating each item
	 */
	print('Testing -- '+(getTickCount()-start)+' -- Lines: '+stringArray.length);
```