### PR TITLE
Add requestChant to Town.js

### DIFF
--- a/d2bs/kolbot/libs/common/Town.js
+++ b/d2bs/kolbot/libs/common/Town.js
@@ -76,6 +76,7 @@ var Town = {
 
 		Attack.weaponSwitch(Attack.getPrimarySlot());
 
+		this.requestChant();
 		this.heal();
 		this.identify();
 		this.shopItems();
@@ -1058,7 +1059,26 @@ CursorLoop:
 
 		return false;
 	},
+	requestChant: function () {
+		if (!Config.ChantRequestAttempts) {
+			return true;
+		}
 
+		if (me.act !== 1) {
+			this.goToTown(1);
+		}
+		this.move(this.tasks[me.act - 1]["CainID"]);
+
+		delay(2000);
+		let count = 0;
+		while (count < Config.ChantRequestAttempts) {
+			say('chant');
+			delay(5000);
+			count++;
+		}
+		delay(2000);
+		return true;
+	},
 	buyKeys: function () {
 		if (!this.wantKeys()) {
 			return true;

--- a/d2bs/kolbot/libs/config/Amazon.js
+++ b/d2bs/kolbot/libs/config/Amazon.js
@@ -231,6 +231,7 @@ function LoadConfig() {
 	Config.HealStatus = false; // Go to a healer if poisoned or cursed
 	Config.UseMerc = true; // Use merc. This is ignored and always false in d2classic.
 	Config.MercWatch = false; // Instant merc revive during battle.
+	Config.ChantRequestAttempts = 0; // How many times to request chant when entering a new game
 
 	// Potion settings
 	Config.UseHP = 75; // Drink a healing potion if life is under designated percent.


### PR DESCRIPTION
Allowing a character to request chant from a chantress in a chant
game before running whatever scripts are configured