### PR TITLE
the repository location is changed

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ If you want to contribute to d2bs/d2bot#, come to irc.synirc.net/d2bs and ask ar
 
 [**Join the Discord Channel!**](https://discord.gg/FuBG8N2)
 
-[**Documentation Repo**](https://github.com/blizzhackers/documentation)
+[**Documentation Repo**](https://github.com/blizzhackers/documentation#diablo-2-botting-system-d2bs)
 
 ## Install dependencies - do this first!
 - [Microsoft Visual C++ 2010 Redistributable Package (x86)](https://www.microsoft.com/en-us/download/details.aspx?id=5555)
@@ -52,7 +52,7 @@ If you want to contribute to d2bs/d2bot#, come to irc.synirc.net/d2bs and ask ar
 ## LimeDrop web based item manager and dropper
 
 - Limedrop is available by default on the master(trunk) branch.
-- [limedrop install and usage](https://github.com/blizzhackers/documentation/blob/master/limedrop/readme.md)
+- [limedrop install and usage](https://github.com/blizzhackers/documentation/tree/master/limedrop#limedrop-guide
 
 
 ![limedrop-general](https://github.com/blizzhackers/documentation/blob/master/limedrop/assets/limedrop-general.png)

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ If you want to contribute to d2bs/d2bot#, come to irc.synirc.net/d2bs and ask ar
 ## LimeDrop web based item manager and dropper
 
 - Limedrop is available by default on the master(trunk) branch.
-- [limedrop install and usage](https://github.com/blizzhackers/documentation/tree/master/limedrop#limedrop-guide
+- [limedrop install and usage](https://github.com/blizzhackers/documentation/tree/master/limedrop#limedrop-guide)
 
 
 ![limedrop-general](https://github.com/blizzhackers/documentation/blob/master/limedrop/assets/limedrop-general.png)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,31 @@
-# D2BS IS NOT SAFE FROM DETECTION!
+# In order to continue the d2bot-with-kolbot project, with more github members involved, the main kolbot repository will be https://github.com/blizzhackers/kolbot
+
+* please join the github team https://github.com/blizzhackers/
+* you'll find all necessary repositories there
+
+## Rules
+
+1. D2BS, D2Bot and kolbot # are educational tools with an open source developer community. These tools are meant to be used offline or on private servers that explicitly allow them. These tools are not meant to be abused on battle.net (a Blizzard Entertainment entity).
+
+2. D2BS, D2Bot and kolbot # are FREE software. If you paid or are asked to pay for these, you have been scammed.
+
+3. do not discuss cheating, maliciously exploiting, or illegal use of software.
+
+4. selling or discussing illegal software or cheating tools are strictly prohibited in all repositories.
+
+## kolbot
+
+* this name is better known than others, even it is just a part of d2bs (diablo 2 botting system) which contain 3 distinct components:
+	* D2BS - core
+	* D2Bot# - manager (C#)
+	* kolbot - script library (JS)
+
+* use the master(trunk) branch
+
+If you want to contribute to kolbot code, make sure you use [ESLint options for kolbot code](https://gist.githubusercontent.com/Nishimura-Katsuo/2d6866666c7acf10047c486a15a7fe60/raw/99ef9c2995929c492ef856772ff346e0f19709cd/.eslintrc.js) or [JSLint options for kolbot code](https://gist.githubusercontent.com/noah-/d917342e52281d54c404e0b2c18b0c6e/raw/fbade95e38b103d2654b90d85ef62a51c4295153/jslint.config) for final polish.
+If you want to contribute to d2bs/d2bot#, come to irc.synirc.net/d2bs and ask around.
+
+# D2BS is NOT SAFE from DETECTION!
 
 [**Join the Forums!**](https://d2bot.discourse.group/)
 
@@ -6,39 +33,26 @@
 
 [**Documentation Repo**](https://github.com/blizzhackers/documentation)
 
-## Install Dependencies - DO THIS FIRST!
+## Install dependencies - do this first!
 - [Microsoft Visual C++ 2010 Redistributable Package (x86)](https://www.microsoft.com/en-us/download/details.aspx?id=5555)
 - [Microsoft .NET Framework 4.0 (or higher)](https://dotnet.microsoft.com/download/dotnet-framework)
 
-## MASTER Branch (also known as TRUNK)
-
-The package contains 3 distinct components:
-- D2BS - core
-- D2Bot# - manager
-- kolbot - script library
-
-If you want to contribute to kolbot code, make sure you use JSLint or ESLint for final polish.
-If you want to contribute to d2bs/d2bot#, come to irc.synirc.net/d2bs and ask around.
-
-- [JSLint options for kolbot code](https://gist.githubusercontent.com/noah-/d917342e52281d54c404e0b2c18b0c6e/raw/fbade95e38b103d2654b90d85ef62a51c4295153/jslint.config)
-- [ESLint options for kolbot code](https://gist.githubusercontent.com/Nishimura-Katsuo/2d6866666c7acf10047c486a15a7fe60/raw/99ef9c2995929c492ef856772ff346e0f19709cd/.eslintrc.js)
-
 ## Getting Started
-- [D2Bot # Manager Setup](https://github.com/kolton/d2bot-with-kolbot/wiki/D2Bot-%23-Manager-Setup)
-- [Installing D2Bot # with Kolbot](https://github.com/kolton/d2bot-with-kolbot/wiki/Installing-d2bot%23-with-kolbot)
-- [.dbj .dbl syntax highlighting](https://github.com/kolton/d2bot-with-kolbot/wiki/.dbj-.dbl-syntax-highlighting)
-- [FAQ](https://github.com/kolton/d2bot-with-kolbot/wiki/FAQ)
+- [download d2bot-with-kolbot](https://github.com/blizzhackers/documentation/blob/master/d2bot/Download.md#download)
+- [d2bot manager setup](https://github.com/blizzhackers/documentation/blob/master/d2bot/ManagerSetup.md/#manager-setup)
+- [notepad++ syntax highlighting](https://github.com/blizzhackers/documentation/blob/master/kolbot/Notepad++.md/#syntax-highlighting-in-np)
+- [FAQ](https://github.com/blizzhackers/documentation/blob/master/kolbot/FAQ.md/#faq)
 
 ## Guides
-**Starter Config**
-- [Kolbot Leader config](https://github.com/kolton/d2bot-with-kolbot/wiki/Kolbot-Leader-config)
-- [Kolbot Leecher config](https://github.com/kolton/d2bot-with-kolbot/wiki/Kolbot-Leecher-Starter)
-- [Kolbot Character config](https://github.com/kolton/d2bot-with-kolbot/wiki/Kolbot-Character-config)
+- [manual playing](https://github.com/blizzhackers/documentation/blob/master/kolbot/ManualPlay.md/#manual-playing)
+- [multi botting](https://github.com/blizzhackers/documentation/blob/master/kolbot/MultiBotting.md/#multi-botting)
+- [character config](https://github.com/blizzhackers/documentation/blob/master/kolbot/CharacterConfig.md/#character-configuration)
+- [TCP/IP Games](https://github.com/blizzhackers/documentation/blob/master/kolbot/TCP-IP%20games.md#tcpip-games)
 
-# LimeDrop Web Based Item Manager and Dropper
-## Setup
-**Limedrop is available by default on the master and unicode branches.**
-- [Limedrop Install and Usage](https://github.com/blizzhackers/documentation/blob/master/limedrop/README.md)
+## LimeDrop web based item manager and dropper
+
+- Limedrop is available by default on the master(trunk) branch.
+- [limedrop install and usage](https://github.com/blizzhackers/documentation/blob/master/limedrop/readme.md)
 
 
-![](https://i.imgur.com/bsmEv3j.png)
+![limedrop-general](https://github.com/blizzhackers/documentation/blob/master/limedrop/assets/limedrop-general.png)


### PR DESCRIPTION
In order to continue the d2bot-with-kolbot project, with more github members involved, the main kolbot repository will be https://github.com/blizzhackers/kolbot

* please join the github team https://github.com/blizzhackers/
* you'll find all necessary repositories there